### PR TITLE
Remove support for Google Maps iframes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,12 +136,6 @@ Steps can be created similar to an ordered list:
 
 Note that steps need an extra line break after the final step (ie. two full blank lines) or other markdown directly afterwards won't work. If you have a subhead after - add a line break after this.
 
-## Maps
-
-Static Maps can be embedded by wrapping the URL in double parenthesis.
-
-    ((http://maps.google.co.uk/maps?q=Winkfield+Rd,+Windsor,+Berkshire+SL4+4AY&hl=en&sll=53.800651,-4.064941&sspn=17.759517,42.055664&vpsrc=0&z=14))
-
 ## Abbreviations
 
 Abbreviations can be defined at the end of the document, and any occurrences elswhere in the document will wrapped in an `<abbr>` tag. They are parsed in the order in which they are defined, so `PCSOs` should be defined before `PCSO`, for example.

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -110,10 +110,6 @@ module Govspeak
       %{\n\n<div class="application-notice help-notice">\n#{Kramdown::Document.new(body.strip).to_html}</div>\n}
     }
 
-    extension('map_link', surrounded_by("((", "))")) { |body|
-      %{<div class="map"><iframe width="200" height="200" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="#{body.strip}&output=embed"></iframe><br /><small><a href="#{body.strip}">View Larger Map</a></small></div>}
-    }
-
     extension('attached-image', /^!!([0-9]+)/) do |image_number|
       image = images[image_number.to_i - 1]
       if image

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -346,13 +346,6 @@ $CTA
   end
 
   test_given_govspeak "
-((http://maps.google.co.uk/maps?q=Winkfield+Rd,+Windsor,+Berkshire+SL4+4AY&hl=en&sll=53.800651,-4.064941&sspn=17.759517,42.055664&vpsrc=0&z=14))
-" do
-    assert_html_output %{<div class="map"><iframe width="200" height="200" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="http://maps.google.co.uk/maps?q=Winkfield+Rd,+Windsor,+Berkshire+SL4+4AY&amp;hl=en&amp;sll=53.800651,-4.064941&amp;sspn=17.759517,42.055664&amp;vpsrc=0&amp;z=14&amp;output=embed"></iframe><br /><small><a href="http://maps.google.co.uk/maps?q=Winkfield+Rd,+Windsor,+Berkshire+SL4+4AY&amp;hl=en&amp;sll=53.800651,-4.064941&amp;sspn=17.759517,42.055664&amp;vpsrc=0&amp;z=14">View Larger Map</a></small></div>}
-    assert_text_output "View Larger Map"
-  end
-
-  test_given_govspeak "
     s1. zippy
     s2. bungle
     s3. george


### PR DESCRIPTION
This code gave someone the ability to insert an arbitrary iframe, which is a serious security vulnerability.

We found one piece of content that uses this in publisher:
https://www.gov.uk/dsa-special-tests-for-instructors

Maybe there are uses in Whitehall?

As you can see, the map is pretty borked anyway. We would alter that content before deploying these changes.

We found this whilst implementing content sanitization for Panopticon/Publisher.
