### PR TITLE
Pass document options to custom parser to fix bug.

### DIFF
--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -22,7 +22,6 @@ module Govspeak
 
     def initialize(source, options = {})
       @source = source ? source.dup : ""
-      Parser.document_domains = options.delete(:document_domains)
       @options = {input: PARSER_CLASS_NAME, entity_output: :symbolic}.merge(options)
       @images = []
     end

--- a/lib/kramdown/parser/kramdown_with_automatic_external_links.rb
+++ b/lib/kramdown/parser/kramdown_with_automatic_external_links.rb
@@ -1,19 +1,35 @@
 require "uri"
+require "kramdown/options"
 
 module Kramdown
+  module Options
+    class AlwaysEqual
+      def ==(other)
+        true
+      end
+    end
+
+    define(:document_domains, Object, %w{www.gov.uk}, <<EOF) do |val|
+Defines the domains which are considered local to the document
+
+Default: www.gov.uk
+Used by: KramdownWithAutomaticExternalLinks
+EOF
+      simple_array_validator(val, :document_domains, AlwaysEqual.new)
+    end
+  end
+
   module Parser
     class KramdownWithAutomaticExternalLinks < Kramdown::Parser::Kramdown
-      class << self
-        attr_writer :document_domains
-        def document_domains
-          @document_domains || %w(www.gov.uk)
-        end
+      def initialize(source, options)
+        @document_domains = options[:document_domains] || %w(www.gov.uk)
+        super
       end
 
       def add_link(el, href, title, alt_text = nil)
         begin
           host = URI.parse(href).host
-          unless host.nil? || (self.class.document_domains.compact.include?(host))
+          unless host.nil? || (@document_domains.compact.include?(host))
             el.attr['rel'] = 'external'
           end
         rescue URI::InvalidURIError, URI::InvalidComponentError

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -338,6 +338,20 @@ $CTA
   end
 
   test_given_govspeak "
+    [internal link](http://www.not-external.com)
+
+    $CTA
+    Click here to start the tool
+    $CTA", [], document_domains: %w(www.not-external.com) do
+    assert_html_output %{
+      <p><a href="http://www.not-external.com">internal link</a></p>
+
+      <div class="call-to-action">
+      <p>Click here to start the tool</p>
+      </div>}
+  end
+
+  test_given_govspeak "
     1. rod
     2. jane
     3. freddy" do

--- a/test/govspeak_test_helper.rb
+++ b/test/govspeak_test_helper.rb
@@ -5,14 +5,15 @@ module GovspeakTestHelper
   end
 
   class GovspeakAsserter
-    def initialize(testcase, govspeak, images = [])
+    def initialize(testcase, govspeak, images = [], options = {})
       @testcase = testcase
       @govspeak = remove_indentation(govspeak)
       @images = images
+      @options = options
     end
 
     def document
-      Govspeak::Document.new(@govspeak).tap do |doc|
+      Govspeak::Document.new(@govspeak, @options).tap do |doc|
         doc.images = @images
       end
     end
@@ -59,15 +60,15 @@ module GovspeakTestHelper
     end
   end
 
-  def given_govspeak(govspeak, images=[], &block)
-    asserter = GovspeakAsserter.new(self, govspeak, images)
+  def given_govspeak(govspeak, images=[], options = {}, &block)
+    asserter = GovspeakAsserter.new(self, govspeak, images, options)
     asserter.instance_eval(&block)
   end
 
   module ClassMethods
-    def test_given_govspeak(govspeak, &block)
+    def test_given_govspeak(govspeak, images=[], options = {}, &block)
       test "Given #{govspeak}" do
-        given_govspeak(govspeak, &block)
+        given_govspeak(govspeak, images, options, &block)
       end
     end
   end


### PR DESCRIPTION
We were seeing a problem where the use of a call-to-action ($CTA)
govspeak extension was breaking the automatic adding of "rel=external"
to external links for Inside Government.

The reason this was breaking was that a number of extensions like
call-to-action cause the construction of another Document instance, but
importantly these other instances were not being passed the same options
as the original document.

The `document_domains` option value was being set as a class instance
variable on the custom parser when the "outer" document instance was
created, but this value was then being overwritten as nil by the
document instances created by the extensions when pre-processing was
run.

Storing the option value as a class instance variable on the custom
parser was always a bit ugly. By digging a bit further into how Kramdown
works, I was able to introduce an intializer for the custom parser which
(once I had defined the `document_domains` option as a valid Kramdown
option) is passed the option value from the original document instance.
This feels like a more robust solution.

I've added a test for the specific scenario we were seeing, but this fix
will also fix the same problem with other extensions that use the
Govspeak::Document parser e.g. "place" ($P), "information" ($I), and
"example" ($E).
