### PR TITLE
Add a $DownloadLink{} extension for the new download link callouts

### DIFF
--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -132,13 +132,11 @@ module Govspeak
       download = Hash[[:title, :url, :format, :size].zip(body.strip.split("|"))]
 
       # :size is an optional value, so filter out any that don't exist.
-      metadata = [:format, :size].map { |meta|
-        [meta, download[meta]]
-      }.select { |key, value|
-        !value.nil?
-      }.map { |key, value|
-        "<li class=\"#{key}\">#{value}</li>"
-      }.join "\n    "
+      metadata = ""
+      [:format, :size].each do |meta|
+        meta_value = download[meta]
+        metadata << "<li class=\"#{meta}\">#{meta_value}</li>" unless meta_value.nil?
+      end
 
       %{
 <div class="download-link">

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -470,8 +470,7 @@ $CTA
       <div class="download-link">
         <p><a href="https://www.gov.uk" rel="external">GOV.UK is the home of the UK Government</a></p>
         <ul class="download-meta">
-          <li class="format">html</li>
-          <li class="size">1.4MB</li>
+          <li class="format">html</li><li class="size">1.4MB</li>
         </ul>
       </div>
       }


### PR DESCRIPTION
These callouts require the existance of file size and file format to
move away from URLs including this metadata (as they currently do).

The suggested markdown extension has been discussed with members of
the content team and they agree that it's understandable.

NOTE: This work came about as part of a spike and may not proceed
past code review. It's just an example to show what could be done.
