### PR TITLE
Adds kramdown footnote link schema to Sanitize config

### DIFF
--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -14,6 +14,7 @@ class Govspeak::HtmlSanitizer
     config[:attributes][:all].push("id", "class")
     config[:attributes]["a"].push("rel")
     config[:elements].push("div", "hr")
+    config[:protocols]["a"]["href"].push("#fn", "#fnref")
     config
   end
 end

--- a/test/html_validator_test.rb
+++ b/test/html_validator_test.rb
@@ -50,7 +50,8 @@ class HtmlValidatorTest < Test::Unit::TestCase
       $P
       """,
       ":england:content goes here:england:",
-      ":scotland:content goes here:scotland:"
+      ":scotland:content goes here:scotland:",
+      "thing with footnote[^1]\n\n[^1]: Some footnote content"
     ]
     values.each do |value|
       assert Govspeak::HtmlValidator.new(value).valid?


### PR DESCRIPTION
Kramdown footnote anchors are generated with id's containing colons, eg: 'fn:1' or 'fnref:1'

Sanitize is seeing those in 'a' tag hrefs as links with dodgy protocols (eg. href="javascript:killThemAll()").
This commit adds the footnote id prefixes to Sanitize's list of allowed protocols to get round the
issue.

Relates to story: https://www.pivotaltracker.com/story/show/60399700
