### PR TITLE
Allow sanitize version 2.0.x

### DIFF
--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -25,7 +25,7 @@ library for use in the UK Government Single Domain project}
 
   s.add_dependency 'kramdown', '~> 0.13.3'
   s.add_dependency 'htmlentities', '~> 4'
-  s.add_dependency "sanitize", "2.0.3"
+  s.add_dependency "sanitize", "~> 2.0.3"
 
   s.add_development_dependency 'rake', '~> 0.9.0'
   s.add_development_dependency 'gem_publisher', '~> 1.1.1'


### PR DESCRIPTION
Instead of requiring 2.0.3.

Sanitize sees id's with colons in 'a' tag hrefs (eg. <a href="#namespace:id">) as being links with protocols.  A pull request has been submitted to sanitize to fix this, but won't be released until version 2.1. A fork has been made with this fix cherry-picked onto sanitize 2.0.6.  This change makes that fork useable when govspeak is included.
