### PR TITLE
New method to_sanitized_html_without_images

### DIFF
--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -39,6 +39,10 @@ module Govspeak
       HtmlSanitizer.new(to_html).sanitize
     end
 
+    def to_sanitized_html_without_images
+      HtmlSanitizer.new(to_html).sanitize_without_images
+    end
+
     def to_text
       HTMLEntities.new.decode(to_html.gsub(/(?:<[^>]+>|\s)+/, " ").strip)
     end

--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -9,6 +9,12 @@ class Govspeak::HtmlSanitizer
     Sanitize.clean(@dirty_html, sanitize_config)
   end
 
+  def sanitize_without_images
+    config = sanitize_config
+    config[:elements].delete('img')
+    Sanitize.clean(@dirty_html, config)
+  end
+
   def sanitize_config
     config = Sanitize::Config::RELAXED.dup
     config[:attributes][:all].push("id", "class")

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -453,6 +453,11 @@ $CTA
   test "can sanitize a document" do
     document = Govspeak::Document.new("<script>doBadThings();</script>")
     assert_equal "doBadThings();", document.to_sanitized_html
+  end  
+
+  test "can sanitize a document without image" do
+    document = Govspeak::Document.new("<script>doBadThings();</script><img src='https://example.com/image.jpg'>")
+    assert_equal "doBadThings();<p></p>", document.to_sanitized_html_without_images
   end
 
   test "identifies a Govspeak document containing malicious HTML as invalid" do

--- a/test/html_sanitizer_test.rb
+++ b/test/html_sanitizer_test.rb
@@ -27,4 +27,9 @@ class HtmlSanitizerTest < Test::Unit::TestCase
     html = "Fortnum & Mason"
     assert_equal "Fortnum &amp; Mason", Govspeak::HtmlSanitizer.new(html).sanitize
   end
+
+  test "can strip images" do
+    html = "<img src='http://example.com/image.jgp'>"
+    assert_equal "", Govspeak::HtmlSanitizer.new(html).sanitize_without_images
+  end
 end


### PR DESCRIPTION
This allows sanitization of govspeak but also strips images, for when
we do not want to allow images. e.g user comments.
