### PR TITLE
Move SimpleCov start into test helper

### DIFF
--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -1,11 +1,5 @@
 # encoding: UTF-8
 
-require 'simplecov'
-require 'simplecov-rcov'
-
-SimpleCov.start
-SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
-
 require 'test_helper'
 require 'govspeak_test_helper'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,9 @@
+require 'simplecov'
+require 'simplecov-rcov'
+
+SimpleCov.start
+SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
+
 $:.unshift(File.expand_path("../lib")) unless $:.include?(File.expand_path("../lib"))
 
 require 'bundler'


### PR DESCRIPTION
SimpleCov must be started at the beginning of the
test suite, the previous position of this call
meant the test suite wouldn't run unless that
that particular test file was loaded first.

Adding another test file revealed that this order
dependence.
