### PR TITLE
Add collapsible lists

### DIFF
--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -184,5 +184,18 @@ module Govspeak
 </div>\n}
       end
     end
+
+    extension("Priority list", /\$PriorityList:(\d+)\n(.*)(?:^\s*\n|\Z)/m) do |number_to_show, body|
+      number_to_show = number_to_show.to_i
+      tagged = 0
+      Kramdown::Document.new(body.strip).to_html.gsub(/<li>/) do |match|
+        if tagged < number_to_show
+          tagged += 1
+          '<li class="primary-item">'
+        else
+          match
+        end
+      end
+    end
   end
 end

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -463,4 +463,31 @@ $CTA
     document = Govspeak::Document.new("<div>some content</div>")
     assert document.valid?
   end
+
+["$PriorityList:3
+ * List item 1
+ * List item 2
+ * List item 3
+ * List item 4
+ * List item 5",
+"$PriorityList:3
+ * List item 1
+ * List item 2
+ * List item 3
+ * List item 4
+ * List item 5
+
+ "].each do |govspeak|
+    test_given_govspeak(govspeak) do
+      assert_html_output %|
+        <ul>
+          <li class="primary-item">List item 1</li>
+          <li class="primary-item">List item 2</li>
+          <li class="primary-item">List item 3</li>
+          <li>List item 4</li>
+          <li>List item 5</li>
+        </ul>
+      |
+    end
+  end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/65362466

Tagging a govspeak list with `$CollapsibleList:n` adds CSS classes which causes the list to collapse after `n` items, with a JS control to reveal them.

Markup as requested by @edds who will be following this up with the JS / CSS to implement the behaviour.
