### PR TITLE
Header metadata serialization

### DIFF
--- a/lib/govspeak/structured_header_extractor.rb
+++ b/lib/govspeak/structured_header_extractor.rb
@@ -8,6 +8,12 @@ module Govspeak
     def top_level?
       level == top_level
     end
+
+    def to_h
+      Hash[members.zip(values)].merge(
+        headers: headers.map(&:to_h),
+      )
+    end
   end
 
   class StructuredHeaderExtractor

--- a/test/govspeak_structured_headers_test.rb
+++ b/test/govspeak_structured_headers_test.rb
@@ -68,6 +68,44 @@ class GovspeakStructuredHeadersTest < Test::Unit::TestCase
     assert_equal "Sub heading 4.2", structured_headers[3].headers[1].text
   end
 
+  test "structured headers serialize to hashes recursively serializing sub headers" do
+    serialized_headers = structured_headers[1].to_h
+
+    expected_serialized_headers = {
+      :text => "Heading 2",
+      :level => 2,
+      :id => "heading-2",
+      :headers =>  [
+        {
+          :text => "Sub heading 2.1",
+          :level => 3,
+          :id => "sub-heading-21",
+          :headers => [],
+        },
+        {
+          :text => "Sub heading 2.2",
+          :level => 3,
+          :id => "sub-heading-22",
+          :headers =>  [
+            {
+              :text => "Sub sub heading 2.2.1",
+              :level => 4,
+              :id => "sub-sub-heading-221",
+              :headers => []
+            },
+          ],
+        },
+        {
+          :text => "Sub heading 2.3",
+          :level => 3, :id=>"sub-heading-23",
+          :headers => []
+        },
+      ],
+    }
+
+    assert_equal expected_serialized_headers, serialized_headers
+  end
+
   def invalid_document_body
     %{
 ### Invalid heading (h3)


### PR DESCRIPTION
As it's Govspeak that parses and creates this nested header data-
structure it seems sensible to put the serialization logic here too.
The serialization itself is trivial and the recursive nature can be
expressed here very simply, with parents serialzing their children.
This is a huge win for clients of this data who need not re-invent
their own recursive serialization logic.
