### PR TITLE
Add track-seen tag support

### DIFF
--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -137,6 +137,10 @@ module Govspeak
       end
     end
 
+    extension('track-seen', /\{@track-seen:(.*)\}/) do |content_identifier|
+      %{<span data-track-seen="#{content_identifier}"></span>}
+    end
+
     def render_image(url, alt_text, caption = nil)
       lines = []
       lines << '<figure class="image embedded">'

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -557,4 +557,15 @@ $PriorityList:1
       |
     end
   end
+
+  test "Content seen tracker tags for analytics are converted" do
+    govspeak = %Q{
+      Some text.{@track-seen:some_text}
+    }
+    given_govspeak(govspeak) do
+      assert_html_output %Q{
+        <p>Some text.<span data-track-seen="some_text"></span></p>
+      }
+    end
+  end
 end


### PR DESCRIPTION
This is part of an effort to allow analytics tracking of whether a
specific piece of content has been seen (scrolled to).

Tags can be added to govspeak content with the tag `{@track-seen:<content identifier for analytics>}`. 
A script will be added to static to find tracker elements (output as `<span data-track-seen="the identifier"></span>`) and send off analytics events when appropriate.
