### PR TITLE
Stop steps list regex matching newlines

### DIFF
--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -159,7 +159,7 @@ module Govspeak
       %{<div class="address"><div class="adr org fn"><p>\n#{body.sub("\n", "").gsub("\n", "<br />")}\n</p></div></div>\n}
     }
 
-    extension("numbered list", /^\s*((s\d+\.\s.*(?:\n|$))+)/) do |body|
+    extension("numbered list", /^[ \t]*((s\d+\.\s.*(?:\n|$))+)/) do |body|
       steps ||= 0
       body.gsub!(/s(\d+)\.\s(.*)(?:\n|$)/) do |b|
           "<li>#{Govspeak::Document.new($2.strip).to_html}</li>\n"

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -375,6 +375,28 @@ $CTA
   end
 
   test_given_govspeak "
+    - unordered
+    - list
+
+    s1. step
+    s2. list
+    " do
+    assert_html_output %{
+      <ul>
+        <li>unordered</li>
+        <li>list</li>
+      </ul>
+
+      <ol class="steps">
+      <li><p>step</p>
+      </li>
+      <li><p>list</p>
+      </li>
+      </ol>}
+    assert_text_output "unordered list step list"
+  end
+
+  test_given_govspeak "
     Zippy, Bungle and George did not qualify for the tax exemption in s428. They filled in their tax return accordingly.
     " do
     assert_html_output %{


### PR DESCRIPTION
The regex used `^\s*` to force the match to be anchored to the start of a line followed by whitespace, but `\s` matches newlines as well as tabs and spaces which causes the replaced markup to not be separated from the content above by a double newline. See test for an example.

This change makes the regex use `[ \t]` to match acceptable whitespace for the start of the line.
