### PR TITLE
Upgrade sanitize dependency to 2.1.0

### DIFF
--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -26,7 +26,7 @@ library for use in the UK Government Single Domain project}
 
   s.add_dependency 'kramdown', '~> 0.13.3'
   s.add_dependency 'htmlentities', '~> 4'
-  s.add_dependency "sanitize", "~> 2.0.3"
+  s.add_dependency "sanitize", "~> 2.1.0"
   s.add_dependency 'nokogiri', '~> 1.5.10'
 
   s.add_development_dependency 'rake', '~> 0.9.0'

--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -24,7 +24,7 @@ class Govspeak::HtmlSanitizer
         :all => Sanitize::Config::RELAXED[:attributes][:all] + [ "id", "class" ],
         "a"  => Sanitize::Config::RELAXED[:attributes]["a"] + [ "rel" ],
       },
-      elements: Sanitize::Config::RELAXED[:elements] + [ "div", "hr" ],
+      elements: Sanitize::Config::RELAXED[:elements] + [ "div" ],
     })
   end
 end


### PR DESCRIPTION
The older version used by govspeak (2.0.3) contains a bug where colons in ids would not be allowed, which prevents footnotes being saved as part of a document body in specialist-publisher.

This was fixed in 2.1.0 (see https://github.com/rgrove/sanitize/pull/87).

Trying to force an upgraded version of sanitize to be activated using the specialist-publisher Gemfile is a non-starter as bundle refuses to upgrade to that version as it's too far ahead of Govspeak's requirements.

Now that this change has been merged in I'm also going to open a whitehall PR to move off an alphagov fork of sanitize back to the official gem.
