### PR TITLE
Don't mutate `sanitize` config

### DIFF
--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -1,6 +1,9 @@
 require 'sanitize'
+require 'with_deep_merge'
 
 class Govspeak::HtmlSanitizer
+  include WithDeepMerge
+
   def initialize(dirty_html)
     @dirty_html = dirty_html
   end
@@ -16,10 +19,12 @@ class Govspeak::HtmlSanitizer
   end
 
   def sanitize_config
-    config = Sanitize::Config::RELAXED.dup
-    config[:attributes][:all].push("id", "class")
-    config[:attributes]["a"].push("rel")
-    config[:elements].push("div", "hr")
-    config
+    deep_merge(Sanitize::Config::RELAXED, {
+      attributes: {
+        :all => Sanitize::Config::RELAXED[:attributes][:all] + [ "id", "class" ],
+        "a"  => Sanitize::Config::RELAXED[:attributes]["a"] + [ "rel" ],
+      },
+      elements: Sanitize::Config::RELAXED[:elements] + [ "div", "hr" ],
+    })
   end
 end

--- a/lib/with_deep_merge.rb
+++ b/lib/with_deep_merge.rb
@@ -1,0 +1,11 @@
+module WithDeepMerge
+  def deep_merge(base_object, other_object)
+    if base_object.is_a?(Hash) && other_object.is_a?(Hash)
+      base_object.merge(other_object) { |_, base_value, other_value|
+        deep_merge(base_value, other_value)
+      }
+    else
+      other_object
+    end
+  end
+end

--- a/test/with_deep_merge_test.rb
+++ b/test/with_deep_merge_test.rb
@@ -1,0 +1,18 @@
+require 'with_deep_merge'
+
+class WithDeepMergeTest < Test::Unit::TestCase
+  include WithDeepMerge
+
+  def test_simple_merge
+    base_hash = { "a" => "b" }
+    other_hash = { "c" => "d" }
+    assert_equal({ "a" => "b", "c" => "d" }, deep_merge(base_hash, other_hash))
+  end
+
+  def test_recursive_merge
+    base_hash = { "a" =>  { "b" => "c", "d" => "e" } }
+    other_hash = { "a" => { "b" => "z", "f" => "g" } }
+    assert_equal({ "a" => { "b" => "z", "d" => "e", "f" => "g" } },
+      deep_merge(base_hash, other_hash))
+  end
+end


### PR DESCRIPTION
Since `Hash#dup` in ruby is shallow and the `sanitize` config is nested, duplicating it
isn't enough to mean that changes to the duplicate are side-effect-free. This change changes the
duplication to a deep-duplication.

The Marshall load/dump pattern is the simplest implementation of deep dup in pure ruby that I've seen.
