### PR TITLE
Force character encoding when validating govspeak

### DIFF
--- a/lib/govspeak/html_validator.rb
+++ b/lib/govspeak/html_validator.rb
@@ -2,7 +2,7 @@ class Govspeak::HtmlValidator
   attr_reader :string
 
   def initialize(string)
-    @string = string
+    @string = string.dup.force_encoding(Encoding::UTF_8)
   end
 
   def invalid?

--- a/test/html_validator_test.rb
+++ b/test/html_validator_test.rb
@@ -7,6 +7,7 @@ class HtmlValidatorTest < Test::Unit::TestCase
       "*bold text*",
       "* bullet",
       "- alternative bullet",
+      "double -- dash -- ndash",
       "+ another bullet",
       "1. Numbered list",
       "s2. Step",


### PR DESCRIPTION
When this is released as 2.0.2 it will fix the test failures on master of govuk_content_models.

In prior versions of Kramdown, UTF-8 strings were always returned
regardless of input. However, in the new version, the character encoding
of the input is maintained.

Nokogiri encodes entities differently in order to return a string of the
same encoding as the input data.

For example:

```
string = "&ndash;"

string.force_encoding("UTF-8")
Nokogiri::HTML.parse(string) => "–"

string.force_encoding("US-ASCII")
Nokogiri::HTML.parse(string) => "&#8211;"
```

The Sanitizer, on the other hand, doesn't always return the same
encoding of string as goes in.

This meant that instead of comparing like for like, after the kramdown
upgrade, the outputs from Nokogiri differed. Hence, failing validations.

By forcing the encoding of the input string to `UTF-8`, we avoid issues
with differing character encodings.
