### PR TITLE
Add an allowed_image_hosts option

### DIFF
--- a/lib/govspeak/html_validator.rb
+++ b/lib/govspeak/html_validator.rb
@@ -1,8 +1,9 @@
 class Govspeak::HtmlValidator
   attr_reader :string
 
-  def initialize(string)
+  def initialize(string, sanitization_options = {})
     @string = string.dup.force_encoding(Encoding::UTF_8)
+    @sanitization_options = sanitization_options
   end
 
   def invalid?
@@ -11,7 +12,7 @@ class Govspeak::HtmlValidator
 
   def valid?
     dirty_html = govspeak_to_html
-    clean_html = Govspeak::HtmlSanitizer.new(dirty_html).sanitize
+    clean_html = Govspeak::HtmlSanitizer.new(dirty_html, @sanitization_options).sanitize
     normalise_html(dirty_html) == normalise_html(clean_html)
   end
 

--- a/test/html_sanitizer_test.rb
+++ b/test/html_sanitizer_test.rb
@@ -28,6 +28,17 @@ class HtmlSanitizerTest < Test::Unit::TestCase
     assert_equal "Fortnum &amp; Mason", Govspeak::HtmlSanitizer.new(html).sanitize
   end
 
+  test "allows images on whitelisted domains" do
+    html = "<img src='http://allowed.com/image.jgp'>"
+    sanitized_html = Govspeak::HtmlSanitizer.new(html, allowed_image_hosts: ['allowed.com']).sanitize
+    assert_equal "<img src=\"http://allowed.com/image.jgp\">", sanitized_html
+  end
+
+  test "removes images not on whitelisted domains" do
+    html = "<img src='http://evil.com/image.jgp'>"
+    assert_equal "", Govspeak::HtmlSanitizer.new(html, allowed_image_hosts: ['allowed.com']).sanitize
+  end
+
   test "can strip images" do
     html = "<img src='http://example.com/image.jgp'>"
     assert_equal "", Govspeak::HtmlSanitizer.new(html).sanitize_without_images

--- a/test/html_validator_test.rb
+++ b/test/html_validator_test.rb
@@ -85,4 +85,9 @@ class HtmlValidatorTest < Test::Unit::TestCase
   test "allow things that will end up as HTML entities" do
     assert Govspeak::HtmlValidator.new("Fortnum & Mason").valid?
   end
+
+  test "optionally disallow images not on a whitelisted domain" do
+    html = "<img src='http://evil.com/image.jgp'>"
+    assert Govspeak::HtmlValidator.new(html, allowed_image_hosts: ['allowed.com']).invalid?
+  end
 end


### PR DESCRIPTION
This lets us specify that images not hosted on GOV.UK (ie relative paths) or on
the GOV.UK asset domain are not sanitary - these images could be changed at the
whim of that website owner, potentially to something malicious.

Currently, we've implemented this in addition to using the Govspeak::HtmlValidator. This means converting every string field in an API request to HTML twice. See: https://github.com/alphagov/hmrc-manuals-api/commit/34b8478a97292c6bed76372f71d3f76ba957509d
