### PR TITLE
Govspeak::Document#valid? can take options

### DIFF
--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -49,8 +49,8 @@ module Govspeak
       HTMLEntities.new.decode(to_html.gsub(/(?:<[^>]+>|\s)+/, " ").strip)
     end
 
-    def valid?
-      Govspeak::HtmlValidator.new(@source).valid?
+    def valid?(validation_options = {})
+      Govspeak::HtmlValidator.new(@source, validation_options).valid?
     end
 
     def headers


### PR DESCRIPTION
Which are passed to HtmlValidator. This enables callers to specify images are
only allowed on certain domains.
