### PR TITLE
Address div was mixed with paragraph text

### DIFF
--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -157,7 +157,7 @@ module Govspeak
     wrap_with_div('call-to-action', '$CTA', Govspeak::Document)
 
     extension('address', surrounded_by("$A")) { |body|
-      %{<div class="address"><div class="adr org fn"><p>\n#{body.sub("\n", "").gsub("\n", "<br />")}\n</p></div></div>\n}
+      %{\n<div class="address"><div class="adr org fn"><p>\n#{body.sub("\n", "").gsub("\n", "<br />")}\n</p></div></div>\n}
     }
 
     extension("legislative list", /(?<=\A|\n\n|\r\n\r\n)^\$LegislativeList\s*$(.*?)\$EndLegislativeList/m) do |body|

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -64,7 +64,20 @@ Testcase Cliffs
 Teston
 0123 456 7890 $A    }
     doc = Govspeak::Document.new(input)
-    assert_equal %{<div class="address"><div class="adr org fn"><p>\n123 Test Street<br />Testcase Cliffs<br />Teston<br />0123 456 7890 \n</p></div></div>\n}, doc.to_html
+    assert_equal %{\n<div class="address"><div class="adr org fn"><p>\n123 Test Street<br />Testcase Cliffs<br />Teston<br />0123 456 7890 \n</p></div></div>\n}, doc.to_html
+  end
+
+  test "address div is separated from paragraph text by a couple of line-breaks" do
+    # else kramdown processes address div as part of paragraph text and escapes HTML
+    input = %{Paragraph1
+
+$A
+123 Test Street
+Testcase Cliffs
+Teston
+0123 456 7890 $A}
+    doc = Govspeak::Document.new(input)
+    assert_equal %{<p>Paragraph1</p>\n\n<div class="address"><div class="adr org fn"><p>\n123 Test Street<br />Testcase Cliffs<br />Teston<br />0123 456 7890 \n</p></div></div>\n}, doc.to_html
   end
 
   test_given_govspeak("^ I am very informational ^") do


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/5680

without a leading line-break character, kramdown considered address `<div>` a part of the preceding paragraph text. this was causing address HTML to get escaped. according to kramdown syntax, there needs to be a blank line to seperate out 2 paragraphs:

http://kramdown.gettalong.org/syntax.html#paragraphs
