### PR TITLE
Allow span elements through HTML validation

### DIFF
--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -45,7 +45,7 @@ class Govspeak::HtmlSanitizer
         :all => Sanitize::Config::RELAXED[:attributes][:all] + [ "id", "class" ],
         "a"  => Sanitize::Config::RELAXED[:attributes]["a"] + [ "rel" ],
       },
-      elements: Sanitize::Config::RELAXED[:elements] + [ "div" ],
+      elements: Sanitize::Config::RELAXED[:elements] + [ "div", "span" ],
     })
   end
 end

--- a/test/html_validator_test.rb
+++ b/test/html_validator_test.rb
@@ -90,4 +90,9 @@ class HtmlValidatorTest < Test::Unit::TestCase
     html = "<img src='http://evil.com/image.jgp'>"
     assert Govspeak::HtmlValidator.new(html, allowed_image_hosts: ['allowed.com']).invalid?
   end
+
+  test "allow <div> and <span> HTML elements" do
+    html = "<div class=\"govspeak\"><h2 id=\"some-title\">\n<span class=\"number\">1. </span> Some title</h2>\n\n<p>Some text</p>\n</div>"
+    assert Govspeak::HtmlValidator.new(html).valid?
+  end
 end


### PR DESCRIPTION
This loosens the rules around HTML sanitisation and validation to allow span
elements. This is required for some [work happening on whitehall](https://www.agileplannerapp.com/boards/173808/cards/6159) to precompute
and store govspeak on HtmlAttachments - the computed HTML contains spans for
numbered headings.
