### PR TITLE
Bump to version 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.0
+
+* `span` elements are now allowed through the sanitization process.
+
 ## 3.1.1
 
 * Fix a bug where address information could get mixed in with preceding paragraph text.

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "3.1.1"
+  VERSION = "3.2.0"
 end


### PR DESCRIPTION
change: `span` elements are now allowed through the sanitization process.
