### PR TITLE
Allow images to be passed in as options

### DIFF
--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -24,8 +24,8 @@ module Govspeak
 
     def initialize(source, options = {})
       @source = source ? source.dup : ""
+      @images = options.delete(:images) || []
       @options = {input: PARSER_CLASS_NAME, entity_output: :symbolic}.merge(options)
-      @images = []
     end
 
     def kramdown_doc

--- a/test/govspeak_test_helper.rb
+++ b/test/govspeak_test_helper.rb
@@ -13,9 +13,7 @@ module GovspeakTestHelper
     end
 
     def document
-      Govspeak::Document.new(@govspeak, @options).tap do |doc|
-        doc.images = @images
-      end
+      Govspeak::Document.new(@govspeak, @options.merge(:images => @images))
     end
 
     def assert_text_output(raw_expected)


### PR DESCRIPTION
Currently it's very clunky working with a `Govspeak::Document` that has images: you have to initialize the document then set the images using the setter, which inevitably results in gymnastics using the `tap` method. This change makes it possible to pass in images to the initializer so the document is ready to roll without any further messing around.
