### PR TITLE
Relax Nokogiri dependency constraint

### DIFF
--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -27,7 +27,7 @@ library for use in the UK Government Single Domain project}
   s.add_dependency 'kramdown', '~> 1.4.1'
   s.add_dependency 'htmlentities', '~> 4'
   s.add_dependency "sanitize", "~> 2.1.0"
-  s.add_dependency 'nokogiri', '~> 1.5.10'
+  s.add_dependency 'nokogiri', '~> 1.5'
 
   s.add_development_dependency 'rake', '~> 0.9.0'
   s.add_development_dependency 'gem_publisher', '~> 1.1.1'


### PR DESCRIPTION
Gem is currently incompatible with Rails 4.2 due to its pessimistic constraint on Nokogiri 1.5.

```
rails (= 4.2.0) ruby depends on
  actionview (= 4.2.0) ruby depends on
    rails-dom-testing (>= 1.0.5, ~> 1.0) ruby depends on
      nokogiri (~> 1.6.0) ruby

govspeak (~> 3.2) ruby depends on
  nokogiri (1.5.11)
```