### PR TITLE
Release version 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.3.0
+
+* Relax Nokogiri dependency to `1.5.x` rather than `1.5.10`. This allows
+  Govspeak to work with Rails 4.2 and greater.
+
 ## 3.2.0
 
 * `span` elements are now allowed through the sanitization process.

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "3.2.0"
+  VERSION = "3.3.0"
 end


### PR DESCRIPTION
Relaxes dependency on Nokogiri so that Rails 4.2 projects can use Govspeak.

Includes #51 