### PR TITLE
Fix a small typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ highlights the enclosed text in yellow
 creates a large pink highlight box with optional preamble text and giant text denoted with `**`
 
     <div class="highlight-answer">
-    <p>The standard VAT rate is <em>20%</em></p>
+    <p>The VAT rate is <em>20%</em></p>
     </div>
 
 ## Points of Contact


### PR DESCRIPTION
There's a small typo in the README that makes it look like Govspeak inserts the word "standard" when talking about VAT in the example `{::highlight-answer}`.