### PR TITLE
Upped kramdown to 1.5.0

### DIFF
--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -24,7 +24,7 @@ library for use in the UK Government Single Domain project}
   s.test_files    = Dir['test/**/*']
   s.require_paths = ["lib"]
 
-  s.add_dependency 'kramdown', '~> 1.4.1'
+  s.add_dependency 'kramdown', '~> 1.5.0'
   s.add_dependency 'htmlentities', '~> 4'
   s.add_dependency "sanitize", "~> 2.1.0"
   s.add_dependency 'nokogiri', '~> 1.5'

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -36,6 +36,10 @@ module Govspeak
     def to_html
       kramdown_doc.to_html
     end
+    
+    def to_liquid
+      to_html
+    end
 
     def to_sanitized_html
       HtmlSanitizer.new(to_html).sanitize


### PR DESCRIPTION
To make compatible with the GitHub pages gem so I could use this with [jekyll](http://jekyllrb.com/) on [our website](http://www.informaticslab.co.uk/). 

I also had to add a `to_liquid` function which just calls `to_html` to get jekyll to build.