### PR TITLE
Release version 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.4.0
+
+* Increase the version of Kramdown to `1.5.0`. This allows compatibility with Jekyll
+  and the GitHub pages gem.
+
 ## 3.3.0
 
 * Relax Nokogiri dependency to `1.5.x` rather than `1.5.10`. This allows

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install the gem
 
 or add it to your Gemfile
 
-    gem "govspeak", "~> 0.8.9"
+    gem "govspeak", "~> 3.4.0"
 
 then create a new document
 

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "3.3.0"
+  VERSION = "3.4.0"
 end


### PR DESCRIPTION
New release as suggested by @jamiecobbett.

This includes the previous increase of Kramdown to `1.5.0` only. I've updated the verson, the CHANGELOG and also the README example.