### PR TITLE
Add statistic headline markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,12 @@ creates a large highlight box with optional preamble text and giant text denoted
 
 Used in HTML publications.
 
-Statistic headlines highlight important numbers in content. Displays a statistic as a large number with a description. The statistic and description must make sense when read aloud. The giant number is denoted with `**`.
+Statistic headlines highlight important numbers in content. Displays a statistic as a large number with a description. The statistic and description must make sense when read aloud. The important number must be wrapped in `**`.
 
 ```
-{::stat-headline}
+{stat-headline}
 *13.8bn* years since the big bang
-{:/stat-headline}
+{/stat-headline}
 ```
 
 Creates the following:

--- a/README.md
+++ b/README.md
@@ -92,32 +92,12 @@ Statistic headlines highlight important numbers in content. Displays a statistic
 {:/stat-headline}
 ```
 
-You can display many statistic headlines together using a group:
-
-```
-{::stat-headline-group}
-{::stat-headline}*13.8bn* years since the big bang{:/stat-headline}
-{::stat-headline}*100bn* stars in our galaxy{:/stat-headline}
-{::stat-headline}*141m* miles to Mars{:/stat-headline}
-{:/stat-headline-group}
-```
-
 Creates the following:
 
 ```html
-<div class="stat-headline-group">
-  <aside class="stat-headline">
-    <p><em>13.8bn</em> years since the big bang</p>
-  </aside>
-
-  <aside class="stat-headline">
-    <p><em>100bn</em> stars in our galaxy</p>
-  </aside>
-
-  <aside class="stat-headline">
-    <p><em>141m</em> miles to Mars</p>
-  </aside>
-</div>
+<aside class="stat-headline">
+  <p><em>13.8bn</em> years since the big bang</p>
+</aside>
 ```
 
 ## Points of Contact

--- a/README.md
+++ b/README.md
@@ -80,6 +80,46 @@ creates a large highlight box with optional preamble text and giant text denoted
     <p>The VAT rate is <em>20%</em></p>
     </div>
 
+### Statistic headline
+
+Used in HTML publications.
+
+Statistic headlines highlight important numbers in content. Displays a statistic as a large number with a description. The statistic and description must make sense when read aloud. The giant number is denoted with `**`.
+
+```
+{::stat-headline}
+*13.8bn* years since the big bang
+{:/stat-headline}
+```
+
+You can display many statistic headlines together using a group:
+
+```
+{::stat-headline-group}
+{::stat-headline}*13.8bn* years since the big bang{:/stat-headline}
+{::stat-headline}*100bn* stars in our galaxy{:/stat-headline}
+{::stat-headline}*141m* miles to Mars{:/stat-headline}
+{:/stat-headline-group}
+```
+
+Creates the following:
+
+```html
+<div class="stat-headline-group">
+  <aside class="stat-headline">
+    <p><em>13.8bn</em> years since the big bang</p>
+  </aside>
+
+  <aside class="stat-headline">
+    <p><em>100bn</em> stars in our galaxy</p>
+  </aside>
+
+  <aside class="stat-headline">
+    <p><em>141m</em> miles to Mars</p>
+  </aside>
+</div>
+```
+
 ## Points of Contact
 
 ### Contact

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ highlights the enclosed text in yellow
     The VAT rate is *20%*
     {:/highlight-answer}
 
-creates a large pink highlight box with optional preamble text and giant text denoted with `**`
+creates a large highlight box with optional preamble text and giant text denoted with `**`
 
     <div class="highlight-answer">
     <p>The VAT rate is <em>20%</em></p>
@@ -90,7 +90,7 @@ creates a large pink highlight box with optional preamble text and giant text de
     **Minicom:** 0845 604 44 34
     $C
 
-creates an contact box
+creates a contact box
 
     <div class="contact">
     <p><strong>Student Finance England</strong><br><strong>Telephone:</strong> 0845 300 50 90<br><strong>Minicom:</strong> 0845 604 44 34</p>

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -36,7 +36,7 @@ module Govspeak
     def to_html
       kramdown_doc.to_html
     end
-    
+
     def to_liquid
       to_html
     end
@@ -112,6 +112,11 @@ module Govspeak
     extension('highlight-answer') { |body|
       %{\n\n<div class="highlight-answer">
 #{Govspeak::Document.new(body.strip).to_html}</div>\n}
+    }
+
+    extension('stat-headline') { |body|
+      %{\n\n<aside class="stat-headline">
+#{Govspeak::Document.new(body.strip).to_html}</aside>\n}
     }
 
     # FIXME: these surrounded_by arguments look dodgy

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -119,11 +119,6 @@ module Govspeak
 #{Govspeak::Document.new(body.strip).to_html}</aside>\n}
     }
 
-    extension('stat-headline-group') { |body|
-      %{\n\n<div class="stat-headline-group">
-#{Govspeak::Document.new(body.strip).to_html}</div>\n}
-    }
-
     # FIXME: these surrounded_by arguments look dodgy
     extension('external', surrounded_by("x[", ")x")) { |body|
       Kramdown::Document.new("[#{body.strip}){:rel='external'}").to_html

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -119,6 +119,11 @@ module Govspeak
 #{Govspeak::Document.new(body.strip).to_html}</aside>\n}
     }
 
+    extension('stat-headline-group') { |body|
+      %{\n\n<div class="stat-headline-group">
+#{Govspeak::Document.new(body.strip).to_html}</div>\n}
+    }
+
     # FIXME: these surrounded_by arguments look dodgy
     extension('external', surrounded_by("x[", ")x")) { |body|
       Kramdown::Document.new("[#{body.strip}){:rel='external'}").to_html

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -114,7 +114,7 @@ module Govspeak
 #{Govspeak::Document.new(body.strip).to_html}</div>\n}
     }
 
-    extension('stat-headline') { |body|
+    extension('stat-headline', %r${stat-headline}(.*?){/stat-headline}$m) { |body|
       %{\n\n<aside class="stat-headline">
 #{Govspeak::Document.new(body.strip).to_html}</aside>\n}
     }

--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -45,7 +45,7 @@ class Govspeak::HtmlSanitizer
         :all => Sanitize::Config::RELAXED[:attributes][:all] + [ "id", "class", "role", "aria-label" ],
         "a"  => Sanitize::Config::RELAXED[:attributes]["a"] + [ "rel" ],
       },
-      elements: Sanitize::Config::RELAXED[:elements] + [ "div", "span" ],
+      elements: Sanitize::Config::RELAXED[:elements] + [ "div", "span", "aside" ],
     })
   end
 end

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -33,6 +33,11 @@ class GovspeakTest < Test::Unit::TestCase
     assert_equal %Q{<p>this </p>\n\n<aside class="stat-headline">\n<p><em>13.8bn</em> Age of the universe in years</p>\n</aside>\n}, rendered
   end
 
+  test "stat-headline-group block extension" do
+    rendered =  Govspeak::Document.new("this \n{::stat-headline-group}\n{::stat-headline}*13.8bn* Age of the universe in years{:/stat-headline}\n{:/stat-headline-group}").to_html
+    assert_equal %Q{<p>this </p>\n\n<div class="stat-headline-group">\n<aside class="stat-headline">\n<p><em>13.8bn</em> Age of the universe in years</p>\n</aside>\n</div>\n}, rendered
+  end
+
   test "extracts headers with text, level and generated id" do
     document =  Govspeak::Document.new %{
 # Big title

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -33,11 +33,6 @@ class GovspeakTest < Test::Unit::TestCase
     assert_equal %Q{<p>this </p>\n\n<aside class="stat-headline">\n<p><em>13.8bn</em> Age of the universe in years</p>\n</aside>\n}, rendered
   end
 
-  test "stat-headline-group block extension" do
-    rendered =  Govspeak::Document.new("this \n{::stat-headline-group}\n{::stat-headline}*13.8bn* Age of the universe in years{:/stat-headline}\n{:/stat-headline-group}").to_html
-    assert_equal %Q{<p>this </p>\n\n<div class="stat-headline-group">\n<aside class="stat-headline">\n<p><em>13.8bn</em> Age of the universe in years</p>\n</aside>\n</div>\n}, rendered
-  end
-
   test "extracts headers with text, level and generated id" do
     document =  Govspeak::Document.new %{
 # Big title

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -29,7 +29,7 @@ class GovspeakTest < Test::Unit::TestCase
   end
 
   test "stat-headline block extension" do
-    rendered =  Govspeak::Document.new("this \n{::stat-headline}*13.8bn* Age of the universe in years{:/stat-headline}").to_html
+    rendered =  Govspeak::Document.new("this \n{stat-headline}*13.8bn* Age of the universe in years{/stat-headline}").to_html
     assert_equal %Q{<p>this </p>\n\n<aside class="stat-headline">\n<p><em>13.8bn</em> Age of the universe in years</p>\n</aside>\n}, rendered
   end
 

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -28,6 +28,11 @@ class GovspeakTest < Test::Unit::TestCase
     assert_equal %Q{<p>this </p>\n\n<div class="highlight-answer">\n<p>Lead in to <em>BIG TEXT</em></p>\n</div>\n}, rendered
   end
 
+  test "stat-headline block extension" do
+    rendered =  Govspeak::Document.new("this \n{::stat-headline}*13.8bn* Age of the universe in years{:/stat-headline}").to_html
+    assert_equal %Q{<p>this </p>\n\n<aside class="stat-headline">\n<p><em>13.8bn</em> Age of the universe in years</p>\n</aside>\n}, rendered
+  end
+
   test "extracts headers with text, level and generated id" do
     document =  Govspeak::Document.new %{
 # Big title


### PR DESCRIPTION
https://trello.com/c/z4YmHWDp/127-html-pubs-add-markdown-to-allow-users-to-add-large-font-and-graphs-medium

> Departments are about to create and publish their Single Departmental Plans. These will be published to GOV.UK as HTML publications. Departments need to be able to pull out important figures periodically throughout the HTML publication in large font.

* Add the `{stat-headline}` markdown pattern
* Add `<aside>` as an acceptable HTML element

See also: https://github.com/alphagov/whitehall/compare/stat-headlines

```
{stat-headline}*13.8bn* years since the big bang{/stat-headline}
```

![screen shot 2015-10-08 at 17 01 17](https://cloud.githubusercontent.com/assets/319055/10372100/37cc7206-6dde-11e5-9194-23ff2264c93f.png)

cc @alextea 