### PR TITLE
Replace URI with Addressable

### DIFF
--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -28,6 +28,7 @@ library for use in the UK Government Single Domain project}
   s.add_dependency 'htmlentities', '~> 4'
   s.add_dependency "sanitize", "~> 2.1.0"
   s.add_dependency 'nokogiri', '~> 1.5'
+  s.add_dependency 'addressable', '~> 2.3.8'
 
   s.add_development_dependency 'rake', '~> 0.9.0'
   s.add_development_dependency 'gem_publisher', '~> 1.1.1'

--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -1,3 +1,4 @@
+require 'addressable/uri'
 require 'sanitize'
 require 'with_deep_merge'
 
@@ -13,7 +14,7 @@ class Govspeak::HtmlSanitizer
       return unless sanitize_context[:node_name] == "img"
 
       node = sanitize_context[:node]
-      image_uri = URI.parse(node['src'])
+      image_uri = Addressable::URI.parse(node['src'])
       unless image_uri.relative? || @allowed_image_hosts.include?(image_uri.host)
         node.unlink # the node isn't sanitary. Remove it from the document.
       end

--- a/lib/kramdown/parser/kramdown_with_automatic_external_links.rb
+++ b/lib/kramdown/parser/kramdown_with_automatic_external_links.rb
@@ -1,4 +1,4 @@
-require "uri"
+require "addressable/uri"
 require "kramdown/options"
 
 module Kramdown
@@ -29,11 +29,11 @@ EOF
       def add_link(el, href, title, alt_text = nil)
         if el.type == :a
           begin
-            host = URI.parse(href).host
+            host = Addressable::URI.parse(href).host
             unless host.nil? || (@document_domains.compact.include?(host))
               el.attr['rel'] = 'external'
             end
-          rescue URI::InvalidURIError, URI::InvalidComponentError
+          rescue Addressable::URI::InvalidURIError
             # it's safe to ignore these very *specific* exceptions
           end
         end

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -262,8 +262,8 @@ Teston
     refute html.include?('rel="external"')
   end
 
-  test "should assume link with an invalid uri component is internal" do
-    html = Govspeak::Document.new("[link](mailto://www.example.com)").to_html
+  test "should treat a mailto as internal" do
+    html = Govspeak::Document.new("[link](mailto:a@b.com)").to_html
     refute html.include?('rel="external"')
   end
 

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -257,12 +257,12 @@ Teston
     assert html.include?("&#165;")
   end
 
-  test "should be assume link with invalid uri is internal" do
+  test "should assume a link with an invalid uri is internal" do
     html = Govspeak::Document.new("[link](:invalid-uri)").to_html
     refute html.include?('rel="external"')
   end
 
-  test "should be assume link with invalid uri component is internal" do
+  test "should assume link with an invalid uri component is internal" do
     html = Govspeak::Document.new("[link](mailto://www.example.com)").to_html
     refute html.include?('rel="external"')
   end

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -265,6 +265,21 @@ Teston
   test "should treat a mailto as internal" do
     html = Govspeak::Document.new("[link](mailto:a@b.com)").to_html
     refute html.include?('rel="external"')
+    assert_equal %Q{<p><a href="mailto:a@b.com">link</a></p>\n}, deobfuscate_mailto(html)
+  end
+
+  test "permits mailto:// URI" do
+    html = Govspeak::Document.new("[link](mailto://a@b.com)").to_html
+    assert_equal %Q{<p><a rel="external" href="mailto://a@b.com">link</a></p>\n}, deobfuscate_mailto(html)
+  end
+
+  test "permits dud mailto: URI" do
+    html = Govspeak::Document.new("[link](mailto:)").to_html
+    assert_equal %Q{<p><a href="mailto:">link</a></p>\n}, deobfuscate_mailto(html)
+  end
+
+  test "permits trailing whitespace in an URI" do
+    Govspeak::Document.new("[link](http://example.com/%20)").to_html
   end
 
   # Regression test - the surrounded_by helper doesn't require the closing x

--- a/test/govspeak_test_helper.rb
+++ b/test/govspeak_test_helper.rb
@@ -63,6 +63,14 @@ module GovspeakTestHelper
     asserter.instance_eval(&block)
   end
 
+  def deobfuscate_mailto(html)
+    # Kramdown obfuscates mailto addresses as an anti-spam measure. It
+    # obfuscates by encoding them as HTML entities.
+    # https://github.com/gettalong/kramdown/blob/7a7bd675b9d2593ad40c26fc4c77bf8407b70b42/lib/kramdown/converter/html.rb#L237-L246
+    coder = HTMLEntities.new
+    coder.decode(html)
+  end
+
   module ClassMethods
     def test_given_govspeak(govspeak, images=[], options = {}, &block)
       test "Given #{govspeak}" do


### PR DESCRIPTION
In order to get past alphagov/govspeak#57 (in summary: ruby 2.2's `URI`
component is strict when parsing particular URIs) we need to switch `URI` for
`Addressable::URI`.

Also clarified copy and intent for `mailto` URI based tests.