### PR TITLE
Improve `headers` method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ rvm:
   - 1.9.3
   - 2.1
   - 2.2
+before_install:
+  - gem update bundler
 script:
   - bundle exec rake
 branches:

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -56,6 +56,43 @@ class GovspeakTest < Minitest::Test
     ], document.headers
   end
 
+  test "extracts headers when nested inside blocks" do
+    document =  Govspeak::Document.new %{
+# First title
+
+<div markdown="1">
+## Nested subtitle
+</div>
+
+<div>
+<div markdown="1">
+### Double nested subtitle
+</div>
+<div markdown="1">
+### Second double subtitle
+</div>
+</div>
+}
+    assert_equal [
+      Govspeak::Header.new('First title', 1, 'first-title'),
+      Govspeak::Header.new('Nested subtitle', 2, 'nested-subtitle'),
+      Govspeak::Header.new('Double nested subtitle', 3, 'double-nested-subtitle'),
+      Govspeak::Header.new('Second double subtitle', 3, 'second-double-subtitle')
+    ], document.headers
+  end
+
+  test "extracts headers with explicitly specified ids" do
+    document =  Govspeak::Document.new %{
+# First title
+
+## Second title {#special}
+}
+    assert_equal [
+      Govspeak::Header.new('First title', 1, 'first-title'),
+      Govspeak::Header.new('Second title', 2, 'special'),
+    ], document.headers
+  end
+
   test "extracts text with no HTML and normalised spacing" do
     input = "# foo\n\nbar    baz  "
     doc = Govspeak::Document.new(input)


### PR DESCRIPTION
Fixes two issues to do with nested headers not being picked up, and where explicitly assigned ID's were being ignored in favoured of the auto-generated versions.

**Please be kind with code review – I'm not a ruby developer 😇**

Example:
```md
# Heading one {#explicit-id}

<div markdown="1">
## Heading two
</div>
```

* When calling `headers`, it was only returning the first heading with an incorrect ID (`#heading` as opposed to `#explicit-id`).
* The `<h2>Heading two</h2>` was not being recognised by the govspeak method, even though it was in the rendered HTML.

Follows the kramdown documentation for [Specifying a Header ID](http://kramdown.gettalong.org/syntax.html#specifying-a-header-id) and [HTML Blocks](http://kramdown.gettalong.org/syntax.html#html-blocks).