### PR TITLE
[DON'T MERGE BUT HELP!] Add failing test for legislative list bug [DON'T SEAL]

### DIFF
--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -569,6 +569,24 @@ $CTA
     }
   end
 
+  test_given_govspeak "This bit of text\r\n\r\n$LegislativeList\r\n* 1. has a footnote[^1]\r\n$EndLegislativeList\r\n[^1]: This is a footnote." do
+    assert_html_output %{
+      <p>This bit of text</p>
+
+      <ol class="legislative-list">
+        <li>1. has a footnote<sup id="fnref:1"><a href="#fn:1" class="footnote">1</a></sup></li>
+      </ol>
+
+      <div class="footnotes">
+        <ol>
+          <li id="fn:1">
+            <p>This is a footnote. <a href="#fnref:1" class="reversefootnote">&#8617;</a></p>
+          </li>
+        </ol>
+      </div>
+    }
+  end
+
   test_given_govspeak "
     Zippy, Bungle and George did not qualify for the tax exemption in s428. They filled in their tax return accordingly.
     " do


### PR DESCRIPTION
When a footnote is inserted in a legislative list, it does not
get processed by govspeak. Other govspeak does get processed, but
footnotes are not standard markdown http://kramdown.gettalong.org/syntax.html#footnotes.

We tried upgrading the kramdown gem to 1.9.0 but that didn't make the
test pass.