### PR TITLE
Allow table cells to have a text alignment

### DIFF
--- a/test/html_sanitizer_test.rb
+++ b/test/html_sanitizer_test.rb
@@ -43,4 +43,22 @@ class HtmlSanitizerTest < Minitest::Test
     html = "<img src='http://example.com/image.jgp'>"
     assert_equal "", Govspeak::HtmlSanitizer.new(html).sanitize_without_images
   end
+
+  test "allows valid text-align properties on the style attribute for table cells and table headings" do
+    ["left", "right", "center"].each do |alignment|
+      html = "<td style=\"text-align: #{alignment}\">thing</td>"
+      assert_equal html, Govspeak::HtmlSanitizer.new(html).sanitize
+    end
+
+    [
+      "width: 10000px",
+      "text-align: middle",
+      "text-align: left; width: 10px",
+      "background-image: url(javascript:alert('XSS'))",
+      "expression(alert('XSS'));"
+    ].each do |style|
+      html = "<td style=\"#{style}\">thing</td>"
+      assert_equal '<td>thing</td>', Govspeak::HtmlSanitizer.new(html).sanitize
+    end
+  end
 end


### PR DESCRIPTION
Kramdown has a markdown pattern for allowing left, centred and right aligned cell contents:
http://kramdown.gettalong.org/quickref.html#tables

To achieve this it uses a style property, eg `style=‘text-align: right’`
https://github.com/gettalong/kramdown/blob/60795eb95f1588d41e105407add2d3ba6a7fc101/lib/kramdown/parser/html.rb#L446-L449

We don’t want to allow any styles to be applied, just the subset that Kramdown uses. Instead, whitelist the attribute for table cells, but use a Sanitise transformer to remove the style unless it matches the 3 possible values it could have.

Part of:
https://trello.com/c/6ld11Eck/346-right-alignment-in-tables-in-govspeak-medium

Markdown example (left aligned, centre aligned, right aligned):
```
| Header1 | Header2 | Header3 |
|:--------|:-------:|--------:|
| cell1   | cell2   | cell3   |
| cell4   | cell5   | cell6   |
```

| Header1 | Header2 | Header3 |
|:--------|:-------:|--------:|
| cell1   | cell2   | cell3   |
| cell4   | cell5   | cell6   |