### PR TITLE
Release 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.6.0
+
+* Update minimum Kramdown version from 1.5.0 to 1.10.0 ([changelog](https://github.com/gettalong/kramdown/tree/2cd02dfacda041d3108a039e085f804645a9d538/doc/news))
+* Allow table columns to be left, right or centre aligned using the [standard markdown pattern](http://kramdown.gettalong.org/quickref.html#tables) provided by Kramdown
+
 ## 3.5.2
 
 * Fix a couple of issues with the [header_extractor](https://github.com/alphagov/govspeak/blob/master/lib/govspeak/header_extractor.rb). The method now picks up headers nested inside `blocks`, and when ID's are [explicitly set](http://kramdown.gettalong.org/syntax.html#specifying-a-header-id). See [https://github.com/alphagov/govspeak/pull/66](https://github.com/alphagov/govspeak/pull/66) for more.

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "3.5.2"
+  VERSION = "3.6.0"
 end


### PR DESCRIPTION
* Update minimum Kramdown version from 1.5.0 to 1.10.0 ([changelog] (https://github.com/gettalong/kramdown/tree/2cd02dfacda041d3108a039e085f804645a9d538/doc/news)) #70
* Allow table columns to be left, right or centre aligned using the [standard markdown pattern](http://kramdown.gettalong.org/quickref.html#tables) provided by Kramdown #71 