### PR TITLE
Allow td and th elements without a style attribute

### DIFF
--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -28,9 +28,13 @@ class Govspeak::HtmlSanitizer
 
       # Kramdown uses text-align to allow table cells to be aligned
       # http://kramdown.gettalong.org/quickref.html#tables
-      unless node['style'].match(/^text-align:\s*(center|left|right)$/)
+      if invalid_style_attribute?(node['style'])
         node.remove_attribute('style')
       end
+    end
+
+    def invalid_style_attribute?(style)
+      style && !style.match(/^text-align:\s*(center|left|right)$/)
     end
   end
 

--- a/test/html_sanitizer_test.rb
+++ b/test/html_sanitizer_test.rb
@@ -44,6 +44,11 @@ class HtmlSanitizerTest < Minitest::Test
     assert_equal "", Govspeak::HtmlSanitizer.new(html).sanitize_without_images
   end
 
+  test "allows table cells and table headings without a style attribute" do
+    html = "<th>thing</th><td>thing</td>"
+    assert_equal html, Govspeak::HtmlSanitizer.new(html).sanitize
+  end
+
   test "allows valid text-align properties on the style attribute for table cells and table headings" do
     ["left", "right", "center"].each do |alignment|
       html = "<td style=\"text-align: #{alignment}\">thing</td>"

--- a/test/html_sanitizer_test.rb
+++ b/test/html_sanitizer_test.rb
@@ -51,7 +51,7 @@ class HtmlSanitizerTest < Minitest::Test
 
   test "allows valid text-align properties on the style attribute for table cells and table headings" do
     ["left", "right", "center"].each do |alignment|
-      html = "<td style=\"text-align: #{alignment}\">thing</td>"
+      html = "<th style=\"text-align: #{alignment}\">thing</th><td style=\"text-align: #{alignment}\">thing</td>"
       assert_equal html, Govspeak::HtmlSanitizer.new(html).sanitize
     end
 
@@ -62,8 +62,8 @@ class HtmlSanitizerTest < Minitest::Test
       "background-image: url(javascript:alert('XSS'))",
       "expression(alert('XSS'));"
     ].each do |style|
-      html = "<td style=\"#{style}\">thing</td>"
-      assert_equal '<td>thing</td>', Govspeak::HtmlSanitizer.new(html).sanitize
+      html = "<th style=\"#{style}\">thing</th><td style=\"#{style}\">thing</td>"
+      assert_equal '<th>thing</th><td>thing</td>', Govspeak::HtmlSanitizer.new(html).sanitize
     end
   end
 end


### PR DESCRIPTION
If no `style` was included `node['style'].match` returned a no method error, so normal tables wouldn’t work correctly.