### PR TITLE
Version 3.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
-## 3.6.0
+## 3.6.1
 
 * Update minimum Kramdown version from 1.5.0 to 1.10.0 ([changelog](https://github.com/gettalong/kramdown/tree/2cd02dfacda041d3108a039e085f804645a9d538/doc/news))
 * Allow table columns to be left, right or centre aligned using the [standard markdown pattern](http://kramdown.gettalong.org/quickref.html#tables) provided by Kramdown
+
+## 3.6.0
+
+* Yanked, see 3.6.1 which includes [fix](https://github.com/alphagov/govspeak/pull/73)
 
 ## 3.5.2
 

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "3.6.0"
+  VERSION = "3.6.1"
 end


### PR DESCRIPTION
Yank version 3.6.0 because of #73 (td and th elements without a style attribute would error)