### PR TITLE
Fix govspeak failures when using IALs on links

### DIFF
--- a/lib/kramdown/parser/kramdown_with_automatic_external_links.rb
+++ b/lib/kramdown/parser/kramdown_with_automatic_external_links.rb
@@ -26,7 +26,7 @@ EOF
         super
       end
 
-      def add_link(el, href, title, alt_text = nil)
+      def add_link(el, href, title, alt_text = nil, ial = nil)
         if el.type == :a
           begin
             host = Addressable::URI.parse(href).host
@@ -42,4 +42,3 @@ EOF
     end
   end
 end
-

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -254,6 +254,16 @@ Teston
     assert_html_output '<p><a rel="external" href="http://www.google.com">external link without x markers</a></p>'
   end
 
+  # Based on Kramdown inline attribute list (IAL) test:
+  # https://github.com/gettalong/kramdown/blob/627978525cf5ee5b290d8a1b8675aae9cc9e2934/test/testcases/span/01_link/link_defs_with_ial.text
+  test_given_govspeak "External link definitions with [attr] and [attr 2] and [attr 3] and [attr before]\n\n[attr]: http://example.com 'title'\n{: hreflang=\"en\" .test}\n\n[attr 2]: http://example.com 'title'\n{: hreflang=\"en\"}\n{: .test}\n\n[attr 3]: http://example.com\n{: .test}\ntest\n\n{: hreflang=\"en\"}\n{: .test}\n[attr before]: http://example.com" do
+    assert_html_output "<p>External link definitions with <a rel=\"external\" hreflang=\"en\" class=\"test\" href=\"http://example.com\" title=\"title\">attr</a> and <a rel=\"external\" hreflang=\"en\" class=\"test\" href=\"http://example.com\" title=\"title\">attr 2</a> and <a rel=\"external\" class=\"test\" href=\"http://example.com\">attr 3</a> and <a rel=\"external\" hreflang=\"en\" class=\"test\" href=\"http://example.com\">attr before</a></p>\n\n<p>test</p>"
+  end
+
+  test_given_govspeak "External link with [inline attribute list] (IAL)\n\n[inline attribute list]: http://example.com 'title'\n{: hreflang=\"en\" .test}" do
+    assert_html_output '<p>External link with <a rel="external" hreflang="en" class="test" href="http://example.com" title="title">inline attribute list</a> (IAL)</p>'
+  end
+
   test_given_govspeak "[external link with rel attribute](http://www.google.com){:rel='next'}" do
     assert_html_output '<p><a rel="next" href="http://www.google.com">external link with rel attribute</a></p>'
   end


### PR DESCRIPTION
Inline attribute lists (IALs) were added to links in Kramdown 1.6.0:
https://github.com/gettalong/kramdown/commit/627978525cf5ee5b290d8a1b8675aae9cc9e2934
http://kramdown.gettalong.org/syntax.html#block-ials
https://github.com/gettalong/kramdown/blob/60795eb95f1588d41e105407add2d3ba6a7fc101/doc/news/release_1_6_0.page

This changed the `add_link` signature. We monkey patch this in `kramdown_with_automatic_external_links` to add “rel=external” but we didn’t update that signature when we bumped Kramdown. There were no tests using the IAL feature so the error was not spotted. Live markdown examples do however trigger this feature, which leads to the error:
```
ArgumentError: wrong number of arguments (5 for 3..4)
```
* Include simple IAL external link test
* Include kramdown’s own IAL link tests

* Fix bug by updating `add_link` method signature

## Question:

I am not sure why existing markdown in content was triggering this IAL feature.