### PR TITLE
Don't allow users to reverse text

### DIFF
--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -105,10 +105,6 @@ module Govspeak
       parser.new(body.strip).to_html.sub(/^<p>(.*)<\/p>$/,"<p><strong>\\1</strong></p>")
     end
 
-    extension('reverse') { |body|
-      body.reverse
-    }
-
     extension('highlight-answer') { |body|
       %{\n\n<div class="highlight-answer">
 #{Govspeak::Document.new(body.strip).to_html}</div>\n}

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -18,11 +18,6 @@ class GovspeakTest < Minitest::Test
     assert_equal "<p><em>this is markdown</em></p>\n", rendered
   end
 
-  test "simple block extension" do
-    rendered =  Govspeak::Document.new("this \n{::reverse}\n*is*\n{:/reverse}\n markdown").to_html
-    assert_equal "<p>this</p>\n\n<p><em>si</em></p>\n\n<p>markdown</p>\n", rendered
-  end
-
   test "highlight-answer block extension" do
     rendered =  Govspeak::Document.new("this \n{::highlight-answer}Lead in to *BIG TEXT*\n{:/highlight-answer}").to_html
     assert_equal %Q{<p>this</p>\n\n<div class="highlight-answer">\n<p>Lead in to <em>BIG TEXT</em></p>\n</div>\n}, rendered


### PR DESCRIPTION
* Reverts` {::reverse}text{:/reverse}` feature
* Feature was included in 4117770acc24b9b4ab07fd54172f3206573fba52 as an initial test of ability to extend markdown
* It shouldn’t be used

Closes #62