### PR TITLE
Use next to return from blocks

### DIFF
--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -184,7 +184,7 @@ module Govspeak
 
     extension('attachment', /\[embed:attachments:([0-9a-f-]+)\]/) do |content_id, body|
       attachment = attachments.detect { |a| a.content_id.match(content_id) }
-      return "" unless attachment
+      next "" unless attachment
       attachment = AttachmentPresenter.new(attachment)
       content = File.read('lib/govspeak/extension/attachment.html.erb')
       ERB.new(content).result(binding)
@@ -192,7 +192,7 @@ module Govspeak
 
     extension('attachment inline', /\[embed:attachments:inline:([0-9a-f-]+)\]/) do |content_id, body|
       attachment = attachments.detect { |a| a.content_id.match(content_id) }
-      return "" unless attachment
+      next "" unless attachment
       attachment = AttachmentPresenter.new(attachment)
       content = File.read('lib/govspeak/extension/inline_attachment.html.erb')
       ERB.new(content).result(binding)

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -909,4 +909,10 @@ Or so we thought.}
     assert_match(/<span class=\"unnumbered-paper\">/, rendered)
     assert_match(/<span class=\"references\">/, rendered)
   end
+
+  test "attachment that isn't provided" do
+    govspeak = "[embed:attachments:906ac8b7-850d-45c6-98e0-9525c680f891]"
+    rendered = Govspeak::Document.new(govspeak).to_html
+    assert_match("", rendered)
+  end
 end


### PR DESCRIPTION
Usage of return here causes a LocalJumpError as the block is attempting to return from a different scope than the block.