### PR TITLE
embed:link markdown extension

### DIFF
--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -21,7 +21,7 @@ module Govspeak
     @@extensions = []
 
     attr_accessor :images
-    attr_reader :attachments, :locale
+    attr_reader :attachments, :links, :locale
 
     def self.to_html(source, options = {})
       new(source, options).to_html
@@ -31,6 +31,7 @@ module Govspeak
       @source = source ? source.dup : ""
       @images = options.delete(:images) || []
       @attachments = Array(options.delete(:attachments))
+      @links = Array(options.delete(:links))
       @locale = options.fetch(:locale, "en")
       @options = {input: PARSER_CLASS_NAME}.merge(options)
       @options[:entity_output] = :symbolic
@@ -266,6 +267,16 @@ module Govspeak
         else
           match
         end
+      end
+    end
+
+    extension('embed link', /\[embed:link:([0-9a-f-]+)\]/) do |content_id|
+      link = links.detect { |l| l.content_id.match(content_id) }
+      next "" unless link
+      if link.url
+        %Q{<a href="#{encode(link.url)}">#{encode(link.title)}</a>}
+      else
+        encode(link.title)
       end
     end
   end

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -915,4 +915,32 @@ Or so we thought.}
     rendered = Govspeak::Document.new(govspeak).to_html
     assert_match("", rendered)
   end
+
+  test "embedded link with link provided" do
+    link = OpenStruct.new(
+      content_id: "5572fee5-f38f-4641-8ffa-64fed9230ad4",
+      url: "https://www.example.com/",
+      title: "Example website"
+    )
+    govspeak = "[embed:link:5572fee5-f38f-4641-8ffa-64fed9230ad4]"
+    rendered = Govspeak::Document.new(govspeak, {links: link}).to_html
+    expected = %r{<a href="https://www.example.com/">Example website</a>}
+    assert_match(expected, rendered)
+  end
+
+  test "embedded link with link not provided" do
+    link = OpenStruct.new(
+      content_id: "e510f1c1-4862-4333-889c-8d3acd443fbf",
+      title: "Example website",
+    )
+    govspeak = "[embed:link:e510f1c1-4862-4333-889c-8d3acd443fbf]"
+    rendered = Govspeak::Document.new(govspeak, {links: link}).to_html
+    assert_match("Example website", rendered)
+  end
+
+  test "embedded link without link object" do
+    govspeak = "[embed:link:0726637c-8c66-47ad-834a-d815cbf51e0e]"
+    rendered = Govspeak::Document.new(govspeak).to_html
+    assert_match("", rendered)
+  end
 end


### PR DESCRIPTION
This adds support for `embed:link:<content_id>` within govspeak. For example if a content item wanted to link to a content item that has a content id of `901c17a5-67ad-4747-aef6-b17e92f73948` the following syntax would be used: `[embed:link:901c17a5-67ad-4747-aef6-b17e92f73948]`.

When the document is rendered this syntax would convert to one of 3 things:

1. `"<a href="{url}">{title}</a>"` - where link title and url is known
2. `"{title}"` - where link title is known but url is not (the content item might be unpublished)
3. `""` - where no link details are available

Links are passed into the Govspeak rendering in the form of an array of struct objects, where they can have a content_id, a title and a url field. When a content item cannot be linked to (for instance only in
draft form or unpublished with gone type). 

It was specified on the card: https://trello.com/c/91KVCf81/754-support-embedded-links-in-the-govspeak-gem-medium that the publication state should be included but this felt like it complicated matters bringing that domain knowledge into this gem. Passing this information would be somewhat complicated as content items can be both draft and published at same time; unpublished and linkable; unpublished but not link; and more. Whereas it can be kept simple by just making the url an optional attribute.