### PR TITLE
Add contacts to govspeak

### DIFF
--- a/config/address_formats.yml
+++ b/config/address_formats.yml
@@ -1,0 +1,366 @@
+# Adapted from https://github.com/yolk/biggs
+# LICENCE: https://raw.github.com/yolk/biggs/master/LICENSE
+#
+# Avaible placeholders:
+#   * fn
+#   * street-address
+#   * postal-code
+#   * locality
+#   * region
+#   * country-name
+#
+---
+ae: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+ar: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{region}}
+    {{country-name}}
+at: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+au: |-
+    {{fn}}
+    {{street-address}}
+    {{locality}} {{region}} {{postal-code}}
+    {{country-name}}
+ba: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+be: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+bg: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+bh: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+br: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}} {{region}}
+    {{country-name}}
+ca: |-
+    {{fn}}
+    {{street-address}}
+    {{locality}} {{region}} {{postal-code}}
+    {{country-name}}
+ch: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+cn: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}} {{region}}
+    {{country-name}}
+cz: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+de: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+dk: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{region}}
+    {{country-name}}
+eg: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+es: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}} {{region}}
+    {{country-name}}
+fi: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+fr: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+gb: |-
+    {{fn}}
+    {{street-address}}
+    {{locality}}
+    {{region}}
+    {{postal-code}}
+    {{country-name}}
+gl: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+gr: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+hk: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}} {{region}}
+    {{country-name}}
+hr: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+hu: |-
+    {{fn}}
+    {{locality}}
+    {{street-address}}
+    {{postal-code}}
+    {{country-name}}
+id: |-
+    {{fn}}
+    {{street-address}}
+    {{locality}}
+    {{region}} {{postal-code}}
+    {{country-name}}
+ie: |-
+    {{fn}}
+    {{street-address}}
+    {{locality}} {{region}} {{postal-code}}
+    {{country-name}}
+il: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+in: |-
+    {{fn}}
+    {{street-address}}
+    {{region}}
+    {{locality}} {{postal-code}}
+    {{country-name}}
+is: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+it: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}} {{region}}
+    {{country-name}}
+jo: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+# Here is a sample of Japanese formatted addresses (Apple Japan HQ).
+# Usually they have "Postal-mark" before postal-code (postal- code,
+# and parts of an address are not separated with space.
+#  Biggs::Formatter.new(:blank_country-name_on => "jp").format(
+#    "jp",
+#    :fn => "アップルジャパン株式会社 本社",
+#    :street-address => "西新宿3-20-2",
+#    :locality => "新宿区",
+#    :region => "東京都",
+#    :postal-code => "163-1480")
+#  〒163-1480
+#  東京都新宿区西新宿3-20-2
+#  アップルジャパン株式会社 本社
+jp: |-
+    〒{{postal-code}}
+    {{region}}{{locality}}{{street-address}}
+    {{fn}}
+    {{country-name}}
+kr: |-
+    {{fn}}
+    {{street-address}}
+    {{locality}} {{region}}
+    {{postal-code}}
+    {{country-name}}
+kw: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{region}}
+    {{country-name}}
+lb: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+li: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+lu: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+mk: |-
+    {{fn}}
+    {{street-address}}
+    {{locality}} {{postal-code}}
+    {{country-name}}
+mx: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}} {{region}}
+    {{country-name}}
+nc: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+nl: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+no: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+nz: |-
+    {{fn}}
+    {{street-address}}
+    {{region}}
+    {{locality}} {{postal-code}}
+    {{country-name}}
+om: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{region}}
+    {{country-name}}
+ph: |-
+    {{fn}}
+    {{street-address}} {{region}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+pl: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{region}}
+    {{country-name}}
+pt: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}} {{region}}
+    {{country-name}}
+qa: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+ro: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+ru: |-
+    {{fn}}
+    {{postal-code}} {{locality}}
+    {{street-address}}
+    {{country-name}}
+sa: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+se: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+sg: |-
+    {{fn}}
+    {{street-address}}
+    {{locality}} {{postal-code}}
+    {{country-name}}
+si: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+sk: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+sy: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+th: |-
+    {{fn}}
+    {{street-address}}
+    {{locality}} {{region}} {{postal-code}}
+    {{country-name}}
+tr: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+tw: |-
+    {{fn}}
+    {{street-address}}
+    {{locality}} {{region}} {{postal-code}}
+    {{country-name}}
+ua: |-
+    {{fn}}
+    {{street-address}}
+    {{locality}} {{region}}
+    {{postal-code}}
+    {{country-name}}
+us: |-
+    {{fn}}
+    {{street-address}}
+    {{locality}} {{region}} {{postal-code}}
+    {{country-name}}
+ye: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{country-name}}
+yu: |-
+    {{fn}}
+    {{street-address}}
+    {{postal-code}} {{locality}}
+    {{region}}
+    {{country-name}}
+za: |-
+    {{fn}}
+    {{street-address}}
+    {{locality}}
+    {{region}}
+    {{postal-code}}
+    {{country-name}}

--- a/lib/presenters/h_card_presenter.rb
+++ b/lib/presenters/h_card_presenter.rb
@@ -1,0 +1,69 @@
+class HCardPresenter
+  def self.from_contact(contact)
+    new(contact_properties(contact), contact.country_code)
+  end
+
+  def self.contact_properties(contact)
+    { 'fn' => contact.recipient,
+      'street-address' => contact.street_address,
+      'postal-code' => contact.postal_code,
+      'locality' => contact.locality,
+      'region' => contact.region,
+      'country-name' => country_name(contact) }
+  end
+
+  def self.country_name(contact)
+    contact.country_name unless contact.country_code == 'GB'
+  end
+
+  def self.property_keys
+    ['fn', 'street-address', 'postal-code', 'locality', 'region', 'country-name']
+  end
+
+  def self.address_formats
+    @address_formats ||= YAML.load_file('config/address_formats.yml')
+  end
+
+  attr_reader :properties, :country_code
+
+  def initialize(properties, country_code)
+    @properties = properties
+    @country_code = country_code
+  end
+
+  def render
+    "<p class=\"adr\">\n#{interpolate_address_template}\n</p>\n".html_safe
+  end
+
+  def interpolate_address_property(property_name)
+    value = properties[property_name]
+
+    if value.present?
+      "<span class=\"#{property_name}\">#{ERB::Util.html_escape(value)}</span>"
+    else
+      ""
+    end
+  end
+
+  private
+
+  def interpolate_address_template
+    address = address_template
+
+    self.class.property_keys.each do |key|
+      address.gsub!(/\{\{#{key}\}\}/, interpolate_address_property(key))
+    end
+
+    address.gsub(/^\n/, '')         # get  rid of blank lines
+           .strip                   # get rid of any trailing whitespace
+           .gsub(/\n/, "<br />\n")  # add break tags where appropriate
+  end
+
+  def address_template
+    (self.class.address_formats[country_code.to_s.downcase] || default_format_string).dup
+  end
+
+  def default_format_string
+    self.class.address_formats['gb']
+  end
+end

--- a/lib/templates/contact.html.erb
+++ b/lib/templates/contact.html.erb
@@ -1,0 +1,42 @@
+<%
+  extra_class = []
+  extra_class << 'postal-address' if contact.has_postal_address?
+%>
+<div id="contact_<%= contact.id %>" class="<%= ['contact', extra_class].flatten.join(' ') %>">
+  <div class="content">
+    <h3><%= contact.title %></h3>
+    <div class="vcard contact-inner">
+    <% if contact.has_postal_address? %>
+      <%= render_hcard_address(contact) %>
+    <% end %>
+    <% if contact.email.present? || contact.contact_form_url.present? || contact.contact_numbers.any? %>
+      <div class="email-url-number">
+      <% if contact.email.present? %>
+        <p class="email">
+          <span class="type"><%= t('contact.email') %></span>
+          <a href="mailto:<%= contact.email %>" class="email"><%= contact.email %></a>
+        </p>
+      <% end %>
+      <% if contact.contact_form_url.present? %>
+        <p class="contact_form_url">
+          <span class="type"><%= t('contact.contact_form') %></span>
+          <a href="<%= contact.contact_form_url %>"><%= contact.contact_form_url.truncate(25) %></a>
+        </p>
+      <% end %>
+      <% contact.contact_numbers.each do |number| %>
+        <p class="tel">
+          <span class="type"><%= number.label %></span>
+          <%= number.number %>
+        </p>
+      <% end %>
+      </div>
+    <% end %>
+    <% if contact.comments.present? %>
+      <p class="comments"><%= auto_link(format_with_html_line_breaks(h(contact.comments))) %></p>
+    <% end %>
+    <% if contact.worldwide_organisation_path %>
+      <a href="<%= contact.worldwide_organisation_path %>">Access and opening times</a>
+    <% end %>
+    </div>
+  </div>
+</div>

--- a/locales/ar.yml
+++ b/locales/ar.yml
@@ -17,3 +17,6 @@ ar:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: "نموذج اتصال"
+    email: "بريد إلكتروني"

--- a/locales/be.yml
+++ b/locales/be.yml
@@ -17,3 +17,6 @@ be:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: "Кантактная форма"
+    email: "Электронная пошта"

--- a/locales/bg.yml
+++ b/locales/bg.yml
@@ -21,3 +21,6 @@ bg:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: "Контактна форма"
+    email: "И-мейл"

--- a/locales/cs.yml
+++ b/locales/cs.yml
@@ -19,3 +19,6 @@ cs:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: Kontaktní formulář
+    email: Email

--- a/locales/cy.yml
+++ b/locales/cy.yml
@@ -18,3 +18,6 @@ cy:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: Ffurflen cysylltu
+    email: E-bost

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -18,3 +18,6 @@ de:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: Kontaktformular
+    email: E-Mail

--- a/locales/el.yml
+++ b/locales/el.yml
@@ -19,3 +19,6 @@ el:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: "Φόρμα επικοινωνίας"
+    email: Email

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -20,3 +20,6 @@ en:
         format
     see_more: See more information about this %{document_type}
     heading: {}
+  contact:
+    email: Email
+    contact_form: Contact form

--- a/locales/es-419.yml
+++ b/locales/es-419.yml
@@ -18,3 +18,6 @@ es-419:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: Formulario de contacto
+    email: Correo electrónico

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -18,3 +18,6 @@ es:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: Formulario de contacto
+    email: Email

--- a/locales/et.yml
+++ b/locales/et.yml
@@ -19,3 +19,6 @@ et:
       help_html: See fail on <a rel="external" href="https://en.wikipedia.org/wiki/OpenDocument_software">OpenDocument</a>
         formaadis
     see_more: 'Loe lähemalt: %{document_type}'
+  contact:
+    contact_form: Võtke ühendust
+    email: E-post

--- a/locales/fa.yml
+++ b/locales/fa.yml
@@ -17,3 +17,6 @@ fa:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: "فرم ارتباط"
+    email: "ایمیل"

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -18,3 +18,6 @@ fr:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: Formulaire de contact
+    email: Email

--- a/locales/he.yml
+++ b/locales/he.yml
@@ -18,3 +18,6 @@ he:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: "טופס יצירת קשר"
+    email: "דואר אלקטרוני"

--- a/locales/hi.yml
+++ b/locales/hi.yml
@@ -18,3 +18,6 @@ hi:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: "संपर्क प्रपत्र"
+    email: "ईमेल"

--- a/locales/hu.yml
+++ b/locales/hu.yml
@@ -18,3 +18,6 @@ hu:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: Kapcsolati űrlap
+    email: E-mail

--- a/locales/hy.yml
+++ b/locales/hy.yml
@@ -18,3 +18,6 @@ hy:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: "Կապի միջոց"
+    email: "Էլելտրոնային հասցե"

--- a/locales/id.yml
+++ b/locales/id.yml
@@ -17,3 +17,6 @@ id:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: Formulir kontak
+    email: Email

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -18,3 +18,6 @@ it:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: Contattaci
+    email: Email

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -16,3 +16,6 @@ ja:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: "連絡フォーム"
+    email: Email

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -16,3 +16,6 @@ ko:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: "콘택트 폼"
+    email: "이메일"

--- a/locales/lt.yml
+++ b/locales/lt.yml
@@ -17,3 +17,6 @@ lt:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: Parašykite mums
+    email: El.paštas

--- a/locales/lv.yml
+++ b/locales/lv.yml
@@ -17,3 +17,6 @@ lv:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: Saziņas forma
+    email: E-pasts

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -19,3 +19,6 @@ pl:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: Formularz kontaktowy
+    email: Email

--- a/locales/ps.yml
+++ b/locales/ps.yml
@@ -17,3 +17,6 @@ ps:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: "د اړیکوپاڼه"
+    email: "برښنالیک"

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -17,3 +17,6 @@ pt:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: Formulário de contato
+    email: E-mail

--- a/locales/ro.yml
+++ b/locales/ro.yml
@@ -21,3 +21,6 @@ ro:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: Formular de contact
+    email: Email

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -16,3 +16,6 @@ ru:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: "Контактная форма"
+    email: "Электронный адрес"

--- a/locales/si.yml
+++ b/locales/si.yml
@@ -17,3 +17,6 @@ si:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: "තොරතුරු පෝරමය"
+    email: "විද්‍යුත් තැපැල්"

--- a/locales/sr.yml
+++ b/locales/sr.yml
@@ -18,3 +18,6 @@ sr:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: formular za kontakt
+    email: e-mail

--- a/locales/ta.yml
+++ b/locales/ta.yml
@@ -19,3 +19,6 @@ ta:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: "தொடர்புகொள்ளல் படிவம்"
+    email: "மின்னஞ்சல்"

--- a/locales/th.yml
+++ b/locales/th.yml
@@ -16,3 +16,6 @@ th:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: "แบบฟอร์มการติดต่อ"
+    email: "อีเมล์"

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -17,3 +17,6 @@ tr:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: "İletişim Formu"
+    email: E-posta

--- a/locales/uk.yml
+++ b/locales/uk.yml
@@ -17,3 +17,6 @@ uk:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: "Форма зворотнього зв'язку"
+    email: "Електронна пошта"

--- a/locales/ur.yml
+++ b/locales/ur.yml
@@ -18,3 +18,6 @@ ur:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: "کانٹیکٹ فارم"
+    email: "ای میل"

--- a/locales/uz.yml
+++ b/locales/uz.yml
@@ -17,3 +17,6 @@ uz:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: Aloqa uchun
+    email: Elektron manzil

--- a/locales/vi.yml
+++ b/locales/vi.yml
@@ -17,3 +17,6 @@ vi:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: Mẫu liên hệ
+    email: Email

--- a/locales/zh-hk.yml
+++ b/locales/zh-hk.yml
@@ -15,3 +15,6 @@ zh-hk:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: "聯絡資料表"
+    email: "電子郵件"

--- a/locales/zh-tw.yml
+++ b/locales/zh-tw.yml
@@ -15,3 +15,6 @@ zh-tw:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: "聯絡資料表"
+    email: "電子郵件"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -15,3 +15,6 @@ zh:
     opendocument:
       help_html: 
     see_more: 
+  contact:
+    contact_form: "联系表格"
+    email: "邮件"

--- a/test/govspeak_contacts_test.rb
+++ b/test/govspeak_contacts_test.rb
@@ -1,0 +1,112 @@
+# encoding: UTF-8
+
+require 'test_helper'
+require 'ostruct'
+
+class GovspeakContactsTest < Minitest::Test
+
+  def build_contact(attrs={})
+    OpenStruct.new(
+      has_postal_address?: attrs.fetch(:has_postal_address?, true),
+      id: attrs.fetch(:id, 123456),
+      content_id: attrs.fetch(:content_id, "4f3383e4-48a2-4461-a41d-f85ea8b89ba0"),
+      title: attrs.fetch(:title, "Government Digital Service"),
+      recipient: attrs.fetch(:recipient, ""),
+      street_address: attrs.fetch(:street_address, "125 Kingsway"),
+      postal_code: attrs.fetch(:postal_code, "WC2B 6NH"),
+      locality: attrs.fetch(:locality, "Holborn"),
+      region: attrs.fetch(:region, "London"),
+      country_code: attrs.fetch(:country_code, "gb"),
+      email: attrs.fetch(:email, "people@digital.cabinet-office.gov.uk"),
+      contact_form_url: attrs.fetch(:contact_form_url, ""),
+      contact_numbers: attrs.fetch(:contact_numbers,
+                                   [OpenStruct.new(label: "helpdesk", number: "+4412345 67890")]),
+      comments: attrs.fetch(:comments, ""),
+      worldwide_organisation_path: attrs.fetch(:worldwide_organisation_path, nil),
+    )
+  end
+
+  def compress_html(html)
+    html.gsub(/[\n\r]+[\s]*/,'')
+  end
+
+  test "contact is rendered when present in options[:contacts]" do
+    contact = build_contact
+    govspeak = "[Contact:4f3383e4-48a2-4461-a41d-f85ea8b89ba0]"
+
+    rendered = Govspeak::Document.new(govspeak, { contacts: [contact] }).to_html
+    expected_html_output = %{
+      <div id="contact_123456" class="contact postal-address">
+        <div class="content">
+          <h3>Government Digital Service</h3>
+          <div class="vcard contact-inner">
+            <p class="adr">
+              <span class="street-address">125 Kingsway</span><br>
+              <span class="locality">Holborn</span><br>
+              <span class="region">London</span><br>
+              <span class="postal-code">WC2B 6NH</span>
+            </p>
+            <div class="email-url-number">
+              <p class="email">
+                <span class="type">Email</span>
+                <a href="mailto:people@digital.cabinet-office.gov.uk" class="email">people@digital.cabinet-office.gov.uk</a>
+              </p>
+              <p class="tel">
+                <span class="type">helpdesk</span>
+                +4412345 67890
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    }
+
+    assert_equal(compress_html(expected_html_output), compress_html(rendered))
+  end
+
+  test "no contact is rendered when contact not present in options[:contacts]" do
+    contact = build_contact(content_id: "19f06142-1b4a-47ce-b257-964badd0a5e2")
+    govspeak = "[Contact:4f3383e4-48a2-4461-a41d-f85ea8b89ba0]"
+    rendered = Govspeak::Document.new(govspeak, { contacts: [contact]}).to_html
+    assert_match("", rendered)
+  end
+
+  test "no contact is rendered when no contacts are supplied" do
+    rendered = Govspeak::Document.new("[Contact:4f3383e4-48a2-4461-a41d-f85ea8b89ba0]").to_html
+    assert_match("", rendered)
+  end
+
+  test "contact with no postal address omits the address info" do
+    contact = build_contact(has_postal_address?: false)
+    govspeak = "[Contact:4f3383e4-48a2-4461-a41d-f85ea8b89ba0]"
+    rendered = Govspeak::Document.new(govspeak, { contacts: [contact] }).to_html
+    expected_html_output = %{
+      <div id="contact_123456" class="contact">
+        <div class="content">
+          <h3>Government Digital Service</h3>
+          <div class="vcard contact-inner">
+            <div class="email-url-number">
+              <p class="email">
+                <span class="type">Email</span>
+                <a href="mailto:people@digital.cabinet-office.gov.uk" class="email">people@digital.cabinet-office.gov.uk</a>
+              </p>
+              <p class="tel">
+                <span class="type">helpdesk</span>
+                +4412345 67890
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    }
+    assert_equal(compress_html(expected_html_output), compress_html(rendered))
+  end
+
+  test "worldwide office contact renders worldwide organisation link" do
+    contact = build_contact(worldwide_organisation_path: "/government/world/organisations/british-antarctic-territory")
+    govspeak = "[Contact:4f3383e4-48a2-4461-a41d-f85ea8b89ba0]"
+    rendered = Govspeak::Document.new(govspeak, { contacts: [contact] }).to_html
+    organisation_link = %Q(<a href="/government/world/organisations/british-antarctic-territory">Access and opening times</a>)
+    assert_match(organisation_link, rendered)
+  end
+end

--- a/test/presenters/h_card_presenter_test.rb
+++ b/test/presenters/h_card_presenter_test.rb
@@ -1,0 +1,153 @@
+# encoding: utf-8
+
+require 'test_helper'
+require 'ostruct'
+
+class HCardPresenterTest < Minitest::Test
+
+  def unindent(html)
+    html.gsub(/^\s+/, '')
+  end
+
+  test "renders address in UK format" do
+    assert_equal unindent(gb_addr), HCardPresenter.new(addr_fields, 'GB').render
+  end
+
+  test "renders address in Spanish format" do
+    assert_equal unindent(es_addr), HCardPresenter.new(addr_fields, 'ES').render
+  end
+
+  test "renders address in Japanese format" do
+    assert_equal unindent(jp_addr), HCardPresenter.new(addr_fields, 'JP').render
+  end
+
+  test "doesn't clobber address formats" do
+    gb_format_before = HCardPresenter.address_formats['gb'].dup
+    HCardPresenter.new(addr_fields, 'GB').render
+
+    assert_equal unindent(gb_format_before), HCardPresenter.address_formats['gb']
+  end
+
+  test "blank properties do not render extra line breaks" do
+    fields_without_region = addr_fields
+    fields_without_region.delete('region')
+
+    assert_equal unindent(addr_without_region), HCardPresenter.new(fields_without_region, 'GB').render
+  end
+
+  test "doesn't render a property when it's a blank string" do
+    fields = addr_fields
+
+    fields['region'] = ''
+    assert_equal unindent(addr_without_region), HCardPresenter.new(fields, 'GB').render
+
+    fields['region'] = '   '
+    assert_equal unindent(addr_without_region), HCardPresenter.new(fields, 'GB').render
+  end
+
+  test 'uses html escaping on property values' do
+    fields = addr_fields
+
+    fields['region'] = 'UK & Channel Islands'
+    assert_includes HCardPresenter.new(fields, 'GB').render, "UK &amp; Channel Islands"
+  end
+
+  test "it defaults to UK format" do
+    assert_equal unindent(gb_addr), HCardPresenter.new(addr_fields, 'FUBAR').render
+  end
+
+  test "it builds from a Contact" do
+    contact = OpenStruct.new(recipient: 'Recipient',
+                             street_address: 'Street',
+                             locality: 'Locality',
+                             region: 'Region',
+                             postal_code: 'Postcode',
+                             country_name: 'Country',
+                             country_code: 'ES')
+    hcard = HCardPresenter.from_contact(contact)
+
+    assert_equal unindent(es_addr), hcard.render
+  end
+
+  test "it leaves out the country name when building a GB contact" do
+    contact = OpenStruct.new(recipient: 'Recipient',
+                             street_address: 'Street',
+                             locality: 'Locality',
+                             region: 'Region',
+                             postal_code: 'Postcode',
+                             country_name: 'Country',
+                             country_code: 'GB')
+    hcard = HCardPresenter.from_contact(contact)
+
+    assert_equal unindent(addr_without_country), hcard.render
+  end
+
+  def addr_fields
+    { 'fn' => 'Recipient',
+      'street-address' => 'Street',
+      'postal-code' => 'Postcode',
+      'locality' => 'Locality',
+      'region' => 'Region',
+      'country-name' => 'Country'
+    }
+  end
+
+  def gb_addr
+    <<-EOF
+    <p class="adr">
+    <span class="fn">Recipient</span><br />
+    <span class="street-address">Street</span><br />
+    <span class="locality">Locality</span><br />
+    <span class="region">Region</span><br />
+    <span class="postal-code">Postcode</span><br />
+    <span class="country-name">Country</span>
+    </p>
+    EOF
+  end
+
+  def es_addr
+    <<-EOF
+    <p class="adr">
+    <span class="fn">Recipient</span><br />
+    <span class="street-address">Street</span><br />
+    <span class="postal-code">Postcode</span> <span class="locality">Locality</span> <span class="region">Region</span><br />
+    <span class="country-name">Country</span>
+    </p>
+    EOF
+  end
+
+  def jp_addr
+    <<-EOF
+    <p class="adr">
+    〒<span class="postal-code">Postcode</span><br />
+    <span class="region">Region</span><span class="locality">Locality</span><span class="street-address">Street</span><br />
+    <span class="fn">Recipient</span><br />
+    <span class="country-name">Country</span>
+    </p>
+    EOF
+  end
+
+  def addr_without_region
+    <<-EOF
+    <p class="adr">
+    <span class="fn">Recipient</span><br />
+    <span class="street-address">Street</span><br />
+    <span class="locality">Locality</span><br />
+    <span class="postal-code">Postcode</span><br />
+    <span class="country-name">Country</span>
+    </p>
+    EOF
+  end
+
+  def addr_without_country
+    <<-EOF
+    <p class="adr">
+    <span class="fn">Recipient</span><br />
+    <span class="street-address">Street</span><br />
+    <span class="locality">Locality</span><br />
+    <span class="region">Region</span><br />
+    <span class="postal-code">Postcode</span>
+    </p>
+    EOF
+  end
+end


### PR DESCRIPTION
https://trello.com/c/0PJ5ureX/753-support-embedded-contacts-in-the-govspeak-gem-medium

Contacts can be inserted into govspeak with the markdown:
`[Contact:4f3383e4-48a2-4461-a41d-f85ea8b89ba0]`
The contact content id denotes a contact within a collection of contacts passed to this gem.
Contacts render as a block level element with many address, phone number and email fields where applicable.
They also allow the address formatting to vary depending on locale.
Worldwide office contacts may also link to a worldwide organisation.