### PR TITLE
Update addressable version to 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.7.0
+
+* Update Addressable version from 2.3.8 to 2.4.0
+
 ## 3.6.2
 
 * Fix bug with link parsing introduced in Kramdown 1.6.0 with the "inline attribute lists" feature which clashed with our monkey patch [#75](https://github.com/alphagov/govspeak/pull/75)

--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -28,7 +28,7 @@ library for use in the UK Government Single Domain project}
   s.add_dependency 'htmlentities', '~> 4'
   s.add_dependency "sanitize", "~> 2.1.0"
   s.add_dependency 'nokogiri', '~> 1.5'
-  s.add_dependency 'addressable', '~> 2.3.8'
+  s.add_dependency 'addressable', '>= 2.3.8', '< 3'
   s.add_dependency 'actionview', '~> 4.1'
   s.add_dependency 'i18n', '~> 0.7'
   s.add_dependency 'money', '~> 6.7'

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "3.6.2"
+  VERSION = "3.7.0"
 end


### PR DESCRIPTION
Trello https://trello.com/c/WLaSMFp0/450-upgrade-govuk-content-api-ruby-dependency-small

It is needed to update ruby version to 2.3.0 on govuk_content_api.

