### PR TITLE
CLI rendering via govspeak binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ then create a new document
     doc = Govspeak::Document.new "^Test^"
     puts doc.to_html
 
+or alternatively, run it from the command line
+
+    $ govspeak "render-me"
+    $ govspeak --file render-me.md
+    $ echo "render-me" | govspeak
+
+options can be passed in through `--options` as a string of JSON or a file
+of JSON can be passed in as `--options-file options.json`.
+
+if installed via bundler prefix commands with bundle exec eg `$ bundle exec govspeak "render-me"`
+
+
 # Extensions
 
 In addition to the [standard Markdown syntax](http://daringfireball.net/projects/markdown/syntax "Markdown syntax"), we have added our own extensions.

--- a/bin/govspeak
+++ b/bin/govspeak
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+
+lib = File.expand_path("../../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require "govspeak/cli"
+
+Govspeak::CLI.new.run

--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
 library for use in the UK Government Single Domain project}
 
   s.files         = Dir[
+    'bin/*',
     'lib/**/*',
     'README.md',
     'CHANGELOG.md',
@@ -22,6 +23,8 @@ library for use in the UK Government Single Domain project}
     'Rakefile'
   ]
   s.test_files    = Dir['test/**/*']
+  s.bindir        = "bin"
+  s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
   s.add_dependency 'kramdown', '~> 1.10.0'
@@ -32,6 +35,7 @@ library for use in the UK Government Single Domain project}
   s.add_dependency 'actionview', '~> 4.1'
   s.add_dependency 'i18n', '~> 0.7'
   s.add_dependency 'money', '~> 6.7'
+  s.add_dependency 'commander', '~> 4.4'
 
   s.add_development_dependency 'rake', '~> 0.9.0'
   s.add_development_dependency 'gem_publisher', '~> 1.1.1'

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -1,4 +1,5 @@
 require 'kramdown'
+require 'active_support/core_ext/hash'
 require 'govspeak/header_extractor'
 require 'govspeak/structured_header_extractor'
 require 'govspeak/html_validator'
@@ -29,6 +30,7 @@ module Govspeak
     end
 
     def initialize(source, options = {})
+      options.deep_symbolize_keys!
       @source = source ? source.dup : ""
       @images = options.delete(:images) || []
       @attachments = Array(options.delete(:attachments))

--- a/lib/govspeak/cli.rb
+++ b/lib/govspeak/cli.rb
@@ -1,0 +1,51 @@
+require 'govspeak/version'
+require 'govspeak'
+require 'commander'
+
+module Govspeak
+  class CLI
+    include Commander::Methods
+
+    def run
+      program(:name, 'Govspeak')
+      program(:version, Govspeak::VERSION)
+      program(:description, "A tool for rendering the GOV.UK dialect of markdown into HTML")
+      default_command(:render)
+      command(:render) do |command|
+        command.syntax = "govspeak render [options] <input>"
+        command.description = "Render Govspeak into HTML, can be sourced from stdin, as an argument or from a file"
+        command.option("--file FILENAME", String, "File to render")
+        command.option("--options JSON", String, "JSON to use as options")
+        command.option("--options-file FILENAME", String, "A file of JSON options")
+        command.action do |args, options|
+          input = get_input($stdin, args, options)
+          raise "Nothing to render. Use --help for assistance" unless input
+          puts Govspeak::Document.new(input, govspeak_options(options)).to_html
+        end
+      end
+      run!
+    end
+
+  private
+
+    def get_input(stdin, args, options)
+      return stdin.read unless stdin.tty?
+      return read_file(options.file) if options.file
+      args.empty? ? nil : args.join(" ")
+    end
+
+    def read_file(file_path)
+      path = Pathname.new(file_path).realpath
+      File.read(path)
+    end
+
+    def govspeak_options(command_options)
+      string = if command_options.options_file
+                read_file(command_options.options_file)
+               else
+                command_options.options
+               end
+      string ? JSON.load(string) : {}
+    end
+  end
+end


### PR DESCRIPTION
This adds in a binary so that you can render govspeak from the command line, hardly an essential feature but it's been very useful in debugging how govspeak interacts. 

I figure it may also be useful if there are any non ruby applications that need to make use of govspeak.

## Usage

- As an argument: `govspeak "render me"`
- From a file: `govspeak --file render-me.md`
- From stdin: `echo "render-me" | govspeak`
- Via bundler: `bundle exec govspeak "render-me"`

Outputs to stdout

Govspeak options can be passed in as JSON as a string through`--options` or as a file through `--options-file options.json`
