### PR TITLE
Don't encode titles of inline attachments

### DIFF
--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -223,9 +223,9 @@ module Govspeak
       end
       next "" unless attachment
       if attachment[:url]
-        %Q{<a href="#{encode(attachment[:url])}">#{encode(attachment[:title])}</a>}
+        %Q{<a href="#{encode(attachment[:url])}">#{attachment[:title]}</a>}
       else
-        encode(attachment[:title])
+        attachment[:title]
       end
     end
 


### PR DESCRIPTION
The result of encoding titles before processing them in Kramdown is that
the straight quotes (&apos;) don't get converted into curly quotes
(&rsquo;), which apparently we favour.

@kevindew - as discussed.