### PR TITLE
Duplicate options passed into Govspeak

### DIFF
--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -32,7 +32,7 @@ module Govspeak
     end
 
     def initialize(source, options = {})
-      options.deep_symbolize_keys!
+      options = options.dup.deep_symbolize_keys
       @source = source ? source.dup : ""
       @images = options.delete(:images) || []
       @attachments = Array.wrap(options.delete(:attachments))


### PR DESCRIPTION
Rather than mutating as we alter it in the initialize method