### PR TITLE
Use markdown to embed links

### DIFF
--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -303,7 +303,7 @@ module Govspeak
       link = links.detect { |l| l[:content_id].match(content_id) }
       next "" unless link
       if link[:url]
-        %Q{<a href="#{encode(link[:url])}">#{link[:title]}</a>}
+        "[#{link[:title]}](#{link[:url]})"
       else
         link[:title]
       end

--- a/test/govspeak_link_test.rb
+++ b/test/govspeak_link_test.rb
@@ -6,27 +6,38 @@ class GovspeakLinkTest < Minitest::Test
   test "embedded link with link provided" do
     link = {
       content_id: "5572fee5-f38f-4641-8ffa-64fed9230ad4",
-      url: "https://www.example.com/",
-      title: "Example website"
+      url: "https://www.gov.uk/example",
+      title: "Example page",
     }
     govspeak = "[embed:link:5572fee5-f38f-4641-8ffa-64fed9230ad4]"
     rendered = Govspeak::Document.new(govspeak, links: link).to_html
-    expected = %r{<a href="https://www.example.com/">Example website</a>}
+    expected = %r{<a href="https://www.gov.uk/example">Example page</a>}
     assert_match(expected, rendered)
   end
 
   test "embedded link with markdown title" do
     link = {
       content_id: "5572fee5-f38f-4641-8ffa-64fed9230ad4",
-      url: "https://www.example.com/",
-      title: "**Example website**"
+      url: "https://www.gov.uk/example",
+      title: "**Example page**",
     }
     govspeak = "[embed:link:5572fee5-f38f-4641-8ffa-64fed9230ad4]"
     rendered = Govspeak::Document.new(govspeak, links: link).to_html
-    expected = %r{<a href="https://www.example.com/"><strong>Example website</strong></a>}
+    expected = %r{<a href="https://www.gov.uk/example"><strong>Example page</strong></a>}
     assert_match(expected, rendered)
   end
 
+  test "embedded link with external url" do
+    link = {
+      content_id: "5572fee5-f38f-4641-8ffa-64fed9230ad4",
+      url: "https://www.example.com/",
+      title: "Example website",
+    }
+    govspeak = "[embed:link:5572fee5-f38f-4641-8ffa-64fed9230ad4]"
+    rendered = Govspeak::Document.new(govspeak, links: link).to_html
+    expected = %r{<a rel="external" href="https://www.example.com/">Example website</a>}
+    assert_match(expected, rendered)
+  end
   test "embedded link with url not provided" do
     link = {
       content_id: "e510f1c1-4862-4333-889c-8d3acd443fbf",


### PR DESCRIPTION
Allows us to benefit from our other link processing aspects, such as
marking links as external