### PR TITLE
Loosen ActionView dep for Rails 5 compatibility.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.gem
 .bundle
 Gemfile.lock
+gemfiles/*.lock
 pkg/*
 .DS_Store
 *.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: ruby
 sudo: false
-rvm:
-  - 2.1
-  - 2.2
-  - 2.3.1
+matrix:
+  include:
+  - rvm: 2.1
+    gemfile: "gemfiles/Gemfile.ruby-2.1"
+  - rvm: 2.2
+    gemfile: "gemfiles/Gemfile.ruby-2.2"
+  - rvm: 2.3.1
+    gemfile: "gemfiles/Gemfile.ruby-2.3.1"
 script:
   - bundle exec rake
 branches:

--- a/gemfiles/Gemfile.ruby-2.1
+++ b/gemfiles/Gemfile.ruby-2.1
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'actionview', '~> 4.1'
+
+gemspec :path => '../'

--- a/gemfiles/Gemfile.ruby-2.2
+++ b/gemfiles/Gemfile.ruby-2.2
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'actionview', '~> 4.1'
+
+gemspec :path => '../'

--- a/gemfiles/Gemfile.ruby-2.3.1
+++ b/gemfiles/Gemfile.ruby-2.3.1
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'actionview', '>= 4.1', '< 6'
+
+gemspec :path => '../'
+

--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -32,7 +32,7 @@ library for use in the UK Government Single Domain project}
   s.add_dependency "sanitize", "~> 2.1.0"
   s.add_dependency 'nokogiri', '~> 1.5'
   s.add_dependency 'addressable', '>= 2.3.8', '< 3'
-  s.add_dependency 'actionview', '~> 4.1'
+  s.add_dependency 'actionview', '>= 4.1', '< 6'
   s.add_dependency 'i18n', '~> 0.7'
   s.add_dependency 'money', '~> 6.7'
   s.add_dependency 'commander', '~> 4.4'


### PR DESCRIPTION
Since Travis builds this gem on different Ruby versions, and ActionView 5 won't install on versions before 2.3, we use a conditional expression in the gemspec to ensure it installs the right one.