### PR TITLE
Add button component for govspeak

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ will output
 
 ### Button
 
-An accessible way to add button links into content, that can also be tracked.
+An accessible way to add button links into content, that can also allow cross domain tracking with [Google Analytics](https://support.google.com/analytics/answer/7372977?hl=en)
 
 This button component is [extended from static](http://govuk-static.herokuapp.com/component-guide/button) for [use in govspeak](http://govuk-static.herokuapp.com/component-guide/govspeak/button)
 Note: Ideally we'd use the original component directly but this currently isnt possible

--- a/README.md
+++ b/README.md
@@ -525,3 +525,65 @@ will output
   </div>
 </div>
 ```
+
+### Button
+
+An accessible way to add button links into content, that can also be tracked.
+
+This button component is [extended from static](http://govuk-static.herokuapp.com/component-guide/button) for [use in govspeak](http://govuk-static.herokuapp.com/component-guide/govspeak/button)
+Note: Ideally we'd use the original component directly but this currently isnt possible
+
+You must use the [link](https://daringfireball.net/projects/markdown/syntax#link) syntax within the button tags.
+
+#### Examples
+
+To get the most basic button.
+
+```
+{button}[Continue](https://gov.uk/random){/button}
+```
+
+which outputs
+
+```html
+<a role="button" class="button" href="https://gov.uk/random">
+  Continue
+</a>
+```
+
+To turn a button into a ['Start now' button](https://www.gov.uk/service-manual/design/start-pages#start-page-elements), you can pass `start` to the button tag.
+
+```
+{button start}[Start Now](https://gov.uk/random){/button}
+```
+
+which outputs
+
+```html
+<a role="button" class="button button-start" href="https://gov.uk/random">
+  Start Now
+</a>
+```
+
+You can pass a Google Analytics [tracking id](https://support.google.com/analytics/answer/7372977?hl=en) which will send page views to another domain, this is used to help services understand the start of their users journeys.
+
+```
+{button start cross-domain-tracking:UA-XXXXXX-Y}
+  [Start Now](https://example.com/external-service/start-now)
+{/button}
+```
+
+which outputs
+
+```html
+<a
+  role="button"
+  class="button button-start"
+  href="https://example.com/external-service/start-now"
+  data-module="cross-domain-tracking"
+  data-tracking-code="UA-XXXXXX-Y"
+  data-tracking-name="govspeakButtonTracker"
+>
+  Start Now
+</a>
+```

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -135,6 +135,33 @@ module Govspeak
       parser.new(body.strip).to_html.sub(/^<p>(.*)<\/p>$/,"<p><strong>\\1</strong></p>")
     end
 
+    extension('button', %r{
+      {button(.*?)} # match opening bracket and capture attributes
+        \s* # any whitespace between opening bracket and link
+        \[ # match start of link markdown
+          ([^\]]+) # capture inside of link markdown
+        \] # match end of link markdown
+        \( # match start of link text markdown
+          ([^)]+)  # capture inside of link text markdown
+        \) # match end of link text markdown
+        \s*  # any whitespace between opening bracket and link
+      {\/button} # match ending bracket
+    }x) { |attributes, text, href|
+      button_classes = "button"
+      button_classes << " button-start" if attributes =~ /start/
+      /cross-domain-tracking:(?<cross_domain_tracking>.[^\s*]+)/ =~ attributes
+      data_attribute = ""
+      if cross_domain_tracking
+        data_attribute << " data-module='cross-domain-tracking'"
+        data_attribute << " data-tracking-code='#{cross_domain_tracking.strip}'"
+        data_attribute << " data-tracking-name='govspeakButtonTracker'"
+      end
+      text = text.strip
+      href = href.strip
+
+      %{\n<a role="button" class="#{button_classes}" href="#{href}" #{data_attribute}>#{text}</a>\n}
+    }
+
     extension('highlight-answer') { |body|
       %{\n\n<div class="highlight-answer">
 #{Govspeak::Document.new(body.strip).to_html}</div>\n}

--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -57,11 +57,19 @@ class Govspeak::HtmlSanitizer
     Sanitize.clean(@dirty_html, config)
   end
 
+  def button_sanitize_config
+    [
+      "data-module='cross-domain-tracking'",
+      "data-tracking-code",
+      "data-tracking-name"
+    ]
+  end
+
   def sanitize_config
     deep_merge(Sanitize::Config::RELAXED, {
       attributes: {
         :all => Sanitize::Config::RELAXED[:attributes][:all] + [ "id", "class", "role", "aria-label" ],
-        "a"  => Sanitize::Config::RELAXED[:attributes]["a"] + [ "rel" ],
+        "a"  => Sanitize::Config::RELAXED[:attributes]["a"] + ["rel"] + button_sanitize_config,
         "th"  => Sanitize::Config::RELAXED[:attributes]["th"] + [ "style" ],
         "td"  => Sanitize::Config::RELAXED[:attributes]["td"] + [ "style" ],
       },

--- a/test/govspeak_button_test.rb
+++ b/test/govspeak_button_test.rb
@@ -1,0 +1,85 @@
+# encoding: UTF-8
+
+require 'test_helper'
+require 'govspeak_test_helper'
+
+require 'ostruct'
+
+class GovspeakTest < Minitest::Test
+  include GovspeakTestHelper
+
+  test_given_govspeak "{button start cross-domain-tracking:UA-23066786-5}[Start now](https://www.registertovote.service.gov.uk/register-to-vote/start){/button}" do
+    assert_html_output '<p><a role="button" class="button button-start" href="https://www.registertovote.service.gov.uk/register-to-vote/start" data-module="cross-domain-tracking" data-tracking-code="UA-23066786-5" data-tracking-name="govspeakButtonTracker">Start now</a></p>'
+    assert_text_output "Start now"
+  end
+
+  # The same as above but with line breaks
+  test_given_govspeak "{button start cross-domain-tracking:UA-23066786-5}\n\n\n[Start now](https://www.registertovote.service.gov.uk/register-to-vote/start)\n\n\n{/button}" do
+    assert_html_output '<p><a role="button" class="button button-start" href="https://www.registertovote.service.gov.uk/register-to-vote/start" data-module="cross-domain-tracking" data-tracking-code="UA-23066786-5" data-tracking-name="govspeakButtonTracker">Start now</a></p>'
+    assert_text_output "Start now"
+  end
+
+  test_given_govspeak "{button cross-domain-tracking:UA-23066786-5}[Start now](https://www.registertovote.service.gov.uk/register-to-vote/start){/button}" do
+    assert_html_output '<p><a role="button" class="button" href="https://www.registertovote.service.gov.uk/register-to-vote/start" data-module="cross-domain-tracking" data-tracking-code="UA-23066786-5" data-tracking-name="govspeakButtonTracker">Start now</a></p>'
+    assert_text_output "Start now"
+  end
+
+  test_given_govspeak "{button start}[Start now](https://www.registertovote.service.gov.uk/register-to-vote/start){/button}" do
+    assert_html_output '<p><a role="button" class="button button-start" href="https://www.registertovote.service.gov.uk/register-to-vote/start">Start now</a></p>'
+    assert_text_output "Start now"
+  end
+
+  test_given_govspeak "{button}[Start now](https://www.registertovote.service.gov.uk/register-to-vote/start){/button}" do
+    assert_html_output '<p><a role="button" class="button" href="https://www.registertovote.service.gov.uk/register-to-vote/start">Start now</a></p>'
+    assert_text_output "Start now"
+  end
+
+  # Test other text outputs
+  test_given_govspeak "{button}[Something else](https://www.registertovote.service.gov.uk/register-to-vote/start){/button}" do
+    assert_html_output '<p><a role="button" class="button" href="https://www.registertovote.service.gov.uk/register-to-vote/start">Something else</a></p>'
+    assert_text_output "Something else"
+  end
+
+  # Test that nothing renders when not given a link
+  test_given_govspeak "{button}I shouldn't render a button{/button}" do
+    assert_html_output '<p>{button}I shouldn’t render a button{/button}</p>'
+  end
+
+  test_given_govspeak "Text before the button {button}[Start Now](http://www.gov.uk){/button} test after the button" do
+    # rubocop:disable Layout/TrailingWhitespace
+    assert_html_output %{
+      <p>Text before the button 
+      <a role="button" class="button" href="http://www.gov.uk">Start Now</a>
+       test after the button</p>
+    }
+    # rubocop:enable Layout/TrailingWhitespace
+    assert_text_output "Text before the button Start Now test after the button"
+  end
+
+  test_given_govspeak "Text before the button with line breaks \n\n\n{button}[Start Now](http://www.gov.uk){/button}\n\n\n test after the button" do
+    assert_html_output %{
+      <p>Text before the button with line breaks</p>
+
+      <p><a role="button" class="button" href="http://www.gov.uk">Start Now</a></p>
+
+      <p>test after the button</p>
+    }
+    assert_text_output "Text before the button with line breaks Start Now test after the button"
+  end
+
+  # Test README examples
+  test_given_govspeak "{button}[Continue](https://gov.uk/random){/button}" do
+    assert_html_output '<p><a role="button" class="button" href="https://gov.uk/random">Continue</a></p>'
+    assert_text_output "Continue"
+  end
+
+  test_given_govspeak "{button start}[Start Now](https://gov.uk/random){/button}" do
+    assert_html_output '<p><a role="button" class="button button-start" href="https://gov.uk/random">Start Now</a></p>'
+    assert_text_output "Start Now"
+  end
+
+  test_given_govspeak "{button start cross-domain-tracking:UA-XXXXXX-Y}[Start Now](https://example.com/external-service/start-now){/button}" do
+    assert_html_output '<p><a role="button" class="button button-start" href="https://example.com/external-service/start-now" data-module="cross-domain-tracking" data-tracking-code="UA-XXXXXX-Y" data-tracking-name="govspeakButtonTracker">Start Now</a></p>'
+    assert_text_output "Start Now"
+  end
+end


### PR DESCRIPTION
Adds a button component for content designers to use.

Includes attributes to ensure buttons have the correct role.

Allows cross-domain-analytics to be passed to the component, this depends on [...]

Places where buttons currently are, with list of hardcoded buttons.

https://docs.google.com/document/d/1DvOWPZBhk9yGy7oMSG2lQwauOJKc-ymFzKH2Qqv4XhQ/edit?usp=sharing

Trello: https://trello.com/c/ppqXaGPk/122-create-a-govspeak-component-for-buttons