### PR TITLE
Ensure data-module is a valid attribute for buttons, Don't match button for inline or indentations

### DIFF
--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -136,6 +136,7 @@ module Govspeak
     end
 
     extension('button', %r{
+      ^ # Match start of line only, allows for indenting code examples
       {button(.*?)} # match opening bracket and capture attributes
         \s* # any whitespace between opening bracket and link
         \[ # match start of link markdown
@@ -146,6 +147,7 @@ module Govspeak
         \) # match end of link text markdown
         \s*  # any whitespace between opening bracket and link
       {\/button} # match ending bracket
+      $ # Match end of line only, allows for indenting code examples
     }x) { |attributes, text, href|
       button_classes = "button"
       button_classes << " button-start" if attributes =~ /start/

--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -59,7 +59,7 @@ class Govspeak::HtmlSanitizer
 
   def button_sanitize_config
     [
-      "data-module='cross-domain-tracking'",
+      "data-module",
       "data-tracking-code",
       "data-tracking-name"
     ]

--- a/test/govspeak_button_test.rb
+++ b/test/govspeak_button_test.rb
@@ -45,17 +45,6 @@ class GovspeakTest < Minitest::Test
     assert_html_output '<p>{button}I shouldn’t render a button{/button}</p>'
   end
 
-  test_given_govspeak "Text before the button {button}[Start Now](http://www.gov.uk){/button} test after the button" do
-    # rubocop:disable Layout/TrailingWhitespace
-    assert_html_output %{
-      <p>Text before the button 
-      <a role="button" class="button" href="http://www.gov.uk">Start Now</a>
-       test after the button</p>
-    }
-    # rubocop:enable Layout/TrailingWhitespace
-    assert_text_output "Text before the button Start Now test after the button"
-  end
-
   test_given_govspeak "Text before the button with line breaks \n\n\n{button}[Start Now](http://www.gov.uk){/button}\n\n\n test after the button" do
     assert_html_output %{
       <p>Text before the button with line breaks</p>
@@ -81,5 +70,13 @@ class GovspeakTest < Minitest::Test
   test_given_govspeak "{button start cross-domain-tracking:UA-XXXXXX-Y}[Start Now](https://example.com/external-service/start-now){/button}" do
     assert_html_output '<p><a role="button" class="button button-start" href="https://example.com/external-service/start-now" data-module="cross-domain-tracking" data-tracking-code="UA-XXXXXX-Y" data-tracking-name="govspeakButtonTracker">Start Now</a></p>'
     assert_text_output "Start Now"
+  end
+
+  # Test indenting button govspeak results in no render, useful in guides
+  test_given_govspeak "    {button start cross-domain-tracking:UA-XXXXXX-Y}[Example](https://example.com/external-service/start-now){/button}" do
+    assert_html_output %{
+      <pre><code>{button start cross-domain-tracking:UA-XXXXXX-Y}[Example](https://example.com/external-service/start-now){/button}
+      </code></pre>
+    }
   end
 end

--- a/test/html_sanitizer_test.rb
+++ b/test/html_sanitizer_test.rb
@@ -28,6 +28,14 @@ class HtmlSanitizerTest < Minitest::Test
     assert_equal "Fortnum &amp; Mason", Govspeak::HtmlSanitizer.new(html).sanitize
   end
 
+  test "allow govspeak button markup" do
+    html = "<a href='#' data-module='cross-domain-tracking' data-tracking-code='UA-XXXXXX-Y' data-tracking-name='govspeakButtonTracker'></a>"
+    assert_equal(
+      "<a href=\"#\" data-module=\"cross-domain-tracking\" data-tracking-code=\"UA-XXXXXX-Y\" data-tracking-name=\"govspeakButtonTracker\"></a>",
+      Govspeak::HtmlSanitizer.new(html).sanitize
+    )
+  end
+
   test "allows images on whitelisted domains" do
     html = "<img src='http://allowed.com/image.jgp'>"
     sanitized_html = Govspeak::HtmlSanitizer.new(html, allowed_image_hosts: ['allowed.com']).sanitize

--- a/test/html_validator_test.rb
+++ b/test/html_validator_test.rb
@@ -95,4 +95,10 @@ class HtmlValidatorTest < Minitest::Test
     html = "<div class=\"govspeak\"><h2 id=\"some-title\">\n<span class=\"number\">1. </span> Some title</h2>\n\n<p>Some text</p>\n</div>"
     assert Govspeak::HtmlValidator.new(html).valid?
   end
+
+  test "allow govspeak button" do
+    assert Govspeak::HtmlValidator.new("{button}[Start now](https://gov.uk){/button}").valid?
+    assert Govspeak::HtmlValidator.new("{button start}[Start now](https://gov.uk){/button}").valid?
+    assert Govspeak::HtmlValidator.new("{button start cross-domain-tracking:UA-XXXXXX-Y}[Start now](https://gov.uk){/button}").valid?
+  end
 end


### PR DESCRIPTION
I made a mistake by not including proper test coverage of the validation of this new feature.

This fixes the mistake and adds the correct tests that should have caught this earlier.

This also makes sure that buttons are only matched when not indented, which will make it easy to include this govspeak in guides.

https://trello.com/c/ppqXaGPk/122-create-a-govspeak-component-for-buttons