### PR TITLE
Fix buttons rendering incorrectly in linebreaks

### DIFF
--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -136,7 +136,7 @@ module Govspeak
     end
 
     extension('button', %r{
-      ^ # Match start of line only, allows for indenting code examples
+      (?:\r|\n|^) # non-capturing match to make sure start of line and linebreak
       {button(.*?)} # match opening bracket and capture attributes
         \s* # any whitespace between opening bracket and link
         \[ # match start of link markdown
@@ -147,7 +147,7 @@ module Govspeak
         \) # match end of link text markdown
         \s*  # any whitespace between opening bracket and link
       {\/button} # match ending bracket
-      $ # Match end of line only, allows for indenting code examples
+      (?:\r|\n|$) # non-capturing match to make sure end of line and linebreak
     }x) { |attributes, text, href|
       button_classes = "button"
       button_classes << " button-start" if attributes =~ /start/

--- a/test/govspeak_button_test.rb
+++ b/test/govspeak_button_test.rb
@@ -79,4 +79,53 @@ class GovspeakTest < Minitest::Test
       </code></pre>
     }
   end
+
+  # Make sure button renders when typical linebreaks are before it, seen in publishing applications
+  test_given_govspeak "{button}[Line breaks](https://gov.uk/random){/button}\r\n\r\n{button}[Continue](https://gov.uk/random){/button}\r\n\r\n{button}[Continue](https://gov.uk/random){/button}" do
+    assert_html_output %{
+      <p><a role="button" class="button" href="https://gov.uk/random">Line breaks</a></p>
+
+      <p><a role="button" class="button" href="https://gov.uk/random">Continue</a></p>
+
+      <p><a role="button" class="button" href="https://gov.uk/random">Continue</a></p>
+    }
+  end
+
+  test_given_govspeak "{button}[More line breaks](https://gov.uk/random){/button}\n\n{button}[Continue](https://gov.uk/random){/button}\n\n{button}[Continue](https://gov.uk/random){/button}" do
+    assert_html_output %{
+      <p><a role="button" class="button" href="https://gov.uk/random">More line breaks</a></p>
+
+      <p><a role="button" class="button" href="https://gov.uk/random">Continue</a></p>
+
+      <p><a role="button" class="button" href="https://gov.uk/random">Continue</a></p>
+    }
+  end
+
+  test_given_govspeak %{
+    ## Register to vote
+
+    Introduction text about the service.
+
+    lorem lorem lorem
+    lorem lorem lorem
+
+    {button start}[Start Now](https://gov.uk/random){/button}
+
+    lorem lorem lorem
+    lorem lorem lorem
+  } do
+    assert_html_output %{
+      <h2 id="register-to-vote">Register to vote</h2>
+
+      <p>Introduction text about the service.</p>
+
+      <p>lorem lorem lorem
+      lorem lorem lorem</p>
+
+      <p><a role="button" class="button button-start" href="https://gov.uk/random">Start Now</a></p>
+
+      <p>lorem lorem lorem
+      lorem lorem lorem</p>
+    }
+  end
 end


### PR DESCRIPTION
When testing with govspeak-preview I found buttons did not render as expected when using the preview mode,
even though they render fine when pulled in as a markdown file.

This ensures that these edge cases are considered and includes a test.

http://rubular.com/r/t7k2i3iwRd