### PR TITLE
Add LinkExtractor class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+* Add a link extraction class for finding links in documents [#120](https://github.com/alphagov/govspeak/pull/120)
+
 ## 5.2.2
 * Fix rendering buttons with inconsistent linebreaks seen in publishing [#118](https://github.com/alphagov/govspeak/pull/118)
 

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -11,6 +11,7 @@ require 'govspeak/html_sanitizer'
 require 'govspeak/kramdown_overrides'
 require 'govspeak/blockquote_extra_quote_remover'
 require 'govspeak/post_processor'
+require 'govspeak/link_extractor'
 require 'govspeak/presenters/attachment_presenter'
 require 'govspeak/presenters/contact_presenter'
 require 'govspeak/presenters/h_card_presenter'
@@ -92,6 +93,10 @@ module Govspeak
 
     def structured_headers
       Govspeak::StructuredHeaderExtractor.new(self).call
+    end
+
+    def extracted_links
+      Govspeak::LinkExtractor.new(self).call
     end
 
     def preprocess(source)

--- a/lib/govspeak/link_extractor.rb
+++ b/lib/govspeak/link_extractor.rb
@@ -1,0 +1,28 @@
+module Govspeak
+  class LinkExtractor
+    def initialize(document)
+      @document = document
+    end
+
+    def call
+      @links ||= extract_links
+    end
+
+  private
+
+    def extract_links
+      document_anchors.map { |link| link['href'] }
+    end
+
+    def document_anchors
+      processed_govspeak.css('a:not([href^="mailto"])').css('a:not([href^="#"])')
+    end
+
+    def processed_govspeak
+      doc = Nokogiri::HTML::Document.new
+      doc.encoding = "UTF-8"
+
+      doc.fragment(@document.to_html)
+    end
+  end
+end

--- a/test/govspeak_link_extractor_test.rb
+++ b/test/govspeak_link_extractor_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class GovspeakLinkExtractorTest < Minitest::Test
+  def document_body
+    %{
+## Heading
+
+[link](http://www.example.com)
+
+[link_two](http://www.gov.com)
+
+[not_a_link](#somepage)
+
+[mailto:](mailto:someone@www.example.com)
+    }
+  end
+
+  def doc
+    @doc ||= Govspeak::Document.new(document_body)
+  end
+
+  def links
+    doc.extracted_links
+  end
+
+  test "Links are extracted from the body" do
+    expected_links = ["http://www.example.com", "http://www.gov.com"]
+    assert_equal expected_links, links
+  end
+
+  test "Other content is not extracted from the body" do
+    refute_includes ["Heading"], links
+  end
+
+  test "Links are not extracted if they begin with #" do
+    refute_includes ["#somepage"], links
+  end
+
+  test "Links are not extracted if they begin with mailto:" do
+    refute_includes ["mailto:someone@www.example.com"], links
+  end
+end


### PR DESCRIPTION
This LinkExtractor class is used in several different publishing applications when checking links on documents. It extracts any links on the document, excluding ones starting with 'mailto:' or '#', and returns an array of the links present. 