### PR TITLE
Bump version to 5.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
-## Unreleased changes
-
+## 5.4.0
 * Add an optional `website_root` argument to `Govspeak::Document#extracted_links` in order to get all links as fully qualified URLs [#122](https://github.com/alphagov/govspeak/pull/122)
 
 ## 5.3.0

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "5.3.0".freeze
+  VERSION = "5.4.0".freeze
 end


### PR DESCRIPTION
This PR releases, and cuts a new gem for the changes made in https://github.com/alphagov/govspeak/pull/122