### PR TITLE
Handle links that have a blank or missing href

### DIFF
--- a/lib/govspeak/link_extractor.rb
+++ b/lib/govspeak/link_extractor.rb
@@ -14,17 +14,22 @@ module Govspeak
     attr_reader :document, :website_root
 
     def extract_links
-      document_anchors.map do |link|
-        if website_root && link['href'].start_with?('/')
-          "#{website_root}#{link['href']}"
-        else
-          link['href']
-        end
+      document_anchors.
+        map { |link| extract_href_from_link(link) }.
+        reject(&:blank?)
+    end
+
+    def extract_href_from_link(link)
+      href = link['href'] || ''
+      if website_root && href.start_with?('/')
+        "#{website_root}#{href}"
+      else
+        href
       end
     end
 
     def document_anchors
-      processed_govspeak.css('a:not([href^="mailto"])').css('a:not([href^="#"])')
+      processed_govspeak.css('a[href]').css('a:not([href^="mailto"])').css('a:not([href^="#"])')
     end
 
     def processed_govspeak

--- a/test/govspeak_link_extractor_test.rb
+++ b/test/govspeak_link_extractor_test.rb
@@ -14,6 +14,20 @@ class GovspeakLinkExtractorTest < Minitest::Test
 [mailto:](mailto:someone@www.example.com)
 
 [absolute_path](/cais-trwydded-yrru-dros-dro)
+
+<a href="http://www.example.com/from/html">raw_html_link</a>
+
+[empty_markdown_link]()
+
+[a_different_empty_markdown_link]( )
+
+<a>empty_raw_html_link</a>
+
+<a href="">a_second_empty_raw_link</a>
+
+<a href=" ">a_third_empty_raw_link</a>
+
+<a href>a_fourth_empty_raw_link</a>
     }
   end
 
@@ -26,7 +40,7 @@ class GovspeakLinkExtractorTest < Minitest::Test
   end
 
   test "Links are extracted from the body" do
-    expected_links = %w{http://www.example.com http://www.gov.com /cais-trwydded-yrru-dros-dro}
+    expected_links = %w{http://www.example.com http://www.gov.com /cais-trwydded-yrru-dros-dro http://www.example.com/from/html}
     assert_equal expected_links, links
   end
 
@@ -40,6 +54,11 @@ class GovspeakLinkExtractorTest < Minitest::Test
 
   test "Links are not extracted if they begin with mailto:" do
     refute_includes ["mailto:someone@www.example.com"], links
+  end
+
+  test "Links are not extracted if they are blank" do
+    refute_includes [""], links
+    refute_includes [nil], links
   end
 
   test "Absolute links are transformed to a url when website_root passed in" do


### PR DESCRIPTION
For: https://trello.com/c/8mDzHj8g/84-1-links-without-href-break-whitehall

If the markdown contains an empty markdown link `[foo]()` or it contains
`a` tags with missing or empty `href` attributes we should strip them out
of the list of hrefs we return.  They're not valid links so there's no
point in checking them.  We use CSS selectors on the document to strip
out any links that have no href attribute (which means we ignore valid
`a` tags like `<a name="table-of-contents">ToC</a>`), but we use ruby to
filter out blank `href` attributes because it's more flexible.