### PR TITLE
Release version 5.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.5.0
+* Ignore links with blank or missing `href`s when extracting links from a document with `Govspeak::Document#extracted_links` [#124](https://github.com/alphagov/govspeak/pull/124)
+
 ## 5.4.0
 * Add an optional `website_root` argument to `Govspeak::Document#extracted_links` in order to get all links as fully qualified URLs [#122](https://github.com/alphagov/govspeak/pull/122)
 

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "5.4.0".freeze
+  VERSION = "5.5.0".freeze
 end


### PR DESCRIPTION
Includes:

* #124 - ignoring links with a blank or missing href when extracting links

Although this change is mostly a bugfix for `Govspeak::Document#extracted_links` so we could consider releasing 5.4.1 instead, the fix does also change the behaviour of `Govspeak::Document#extracted_links` so a bigger version bump felt more appropriate.