### PR TITLE
Bring gem up to date with other GOV.UK gems

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,3 +2,5 @@ Metrics/BlockLength:
   Exclude:
     - '*.gemspec'
     - 'test/**/*'
+Style/TrivialAccessors:
+  IgnoreClassMethods: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,4 @@
+Metrics/BlockLength:
+  Exclude:
+    - '*.gemspec'
+    - 'test/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Update ActionView to 5.x
+
 ## 5.6.0
 
 * Update sanitize version to 4.6.x [#127](https://github.com/alphagov/govspeak/issues/127)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,64 +2,6 @@
 
 library("govuk")
 
-REPOSITORY = "govspeak"
-
-def rubyVersions = [
-  "2.1",
-  "2.2",
-  "2.3.1",
-]
-
 node {
-
-  try {
-    stage("Checkout") {
-      checkout(scm)
-      govuk.mergeMasterBranch()
-    }
-
-    for (rubyVersion in rubyVersions) {
-      stage("Test with ruby $rubyVersion") {
-        govuk.cleanupGit()
-        govuk.setEnvar("RBENV_VERSION", rubyVersion)
-        govuk.setEnvar("BUNDLE_GEMFILE", "gemfiles/Gemfile.ruby-${rubyVersion}")
-        govuk.bundleGem()
-
-        govuk.rubyLinter("bin lib test")
-
-        govuk.runTests()
-
-        publishHTML(target: [
-          allowMissing: false,
-          alwaysLinkToLastBuild: false,
-          keepAll: true,
-          reportDir: "coverage/rcov",
-          reportFiles: "index.html",
-          reportName: "RCov Report ${rubyVersion}"
-        ])
-      }
-    }
-    sh("unset RBENV_VERSION")
-    sh("unset BUNDLE_GEMFILE")
-
-    if (env.BRANCH_NAME == "master") {
-      stage("Push release tag") {
-        echo("Pushing tag")
-        govuk.pushTag(REPOSITORY, env.BRANCH_NAME, "release_" + env.BUILD_NUMBER)
-      }
-
-      stage("Publish gem") {
-        echo("Publishing gem")
-        govuk.publishGem(REPOSITORY, env.BRANCH_NAME)
-      }
-    }
-
-  } catch (e) {
-    currentBuild.result = "FAILED"
-    step([$class: "Mailer",
-          notifyEveryUnstableBuild: true,
-          recipients: "govuk-ci-notifications@digital.cabinet-office.gov.uk",
-          sendToIndividuals: true])
-    throw e
-  }
+  govuk.buildProject(rubyLintDiff: false)
 }

--- a/Rakefile
+++ b/Rakefile
@@ -12,10 +12,4 @@ Rake::TestTask.new("test") { |t|
   t.warning = true
 }
 
-require "gem_publisher"
-task :publish_gem do |_t|
-  gem = GemPublisher.publish_if_updated("govspeak.gemspec", :rubygems)
-  puts "Published #{gem}" if gem
-end
-
 task default: [:test]

--- a/Rakefile
+++ b/Rakefile
@@ -13,9 +13,9 @@ Rake::TestTask.new("test") { |t|
 }
 
 require "gem_publisher"
-task :publish_gem do |t|
+task :publish_gem do |_t|
   gem = GemPublisher.publish_if_updated("govspeak.gemspec", :rubygems)
   puts "Published #{gem}" if gem
 end
 
-task :default => [:test]
+task default: [:test]

--- a/bin/govspeak
+++ b/bin/govspeak
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-lib = File.expand_path("../../lib", __FILE__)
+lib = File.expand_path('../lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require "govspeak/cli"

--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -28,7 +28,7 @@ library for use in the UK Government Single Domain project'
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.require_paths = %w[lib]
 
-  s.add_dependency 'actionview', '>= 4.1', '< 6'
+  s.add_dependency 'actionview', '~> 5.0'
   s.add_dependency 'addressable', '>= 2.3.8', '< 3'
   s.add_dependency 'commander', '~> 4.4'
   s.add_dependency 'htmlentities', '~> 4'

--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
+
+$:.push File.expand_path('lib', __dir__)
 
 require 'govspeak/version'
 
@@ -10,9 +11,9 @@ Gem::Specification.new do |s|
   s.authors       = ["GOV.UK Dev"]
   s.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
   s.homepage      = "http://github.com/alphagov/govspeak"
-  s.summary       = %q{Markup language for single domain}
-  s.description   = %q{A set of extensions to markdown layered on top of the kramdown
-library for use in the UK Government Single Domain project}
+  s.summary       = 'Markup language for single domain'
+  s.description   = 'A set of extensions to markdown layered on top of the kramdown
+library for use in the UK Government Single Domain project'
 
   s.files         = Dir[
     'bin/*',
@@ -25,23 +26,23 @@ library for use in the UK Government Single Domain project}
   s.test_files    = Dir['test/**/*']
   s.bindir        = "bin"
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  s.require_paths = ["lib"]
+  s.require_paths = %w[lib]
 
-  s.add_dependency 'kramdown', '~> 1.15.0'
-  s.add_dependency 'htmlentities', '~> 4'
-  s.add_dependency "sanitize", "~> 4.6"
-  s.add_dependency 'nokogiri', '~> 1.5'
-  s.add_dependency 'addressable', '>= 2.3.8', '< 3'
   s.add_dependency 'actionview', '>= 4.1', '< 6'
-  s.add_dependency 'i18n', '~> 0.7'
-  s.add_dependency 'money', '~> 6.7'
+  s.add_dependency 'addressable', '>= 2.3.8', '< 3'
   s.add_dependency 'commander', '~> 4.4'
+  s.add_dependency 'htmlentities', '~> 4'
+  s.add_dependency 'i18n', '~> 0.7'
+  s.add_dependency 'kramdown', '~> 1.15.0'
+  s.add_dependency 'money', '~> 6.7'
+  s.add_dependency 'nokogiri', '~> 1.5'
+  s.add_dependency "sanitize", "~> 4.6"
 
-  s.add_development_dependency 'rake', '~> 0.9.0'
   s.add_development_dependency 'gem_publisher', '~> 1.1.1'
+  s.add_development_dependency 'govuk-lint'
   s.add_development_dependency 'minitest', '~> 5.8.3'
+  s.add_development_dependency 'pry-byebug'
+  s.add_development_dependency 'rake', '~> 0.9.0'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'simplecov-rcov'
-  s.add_development_dependency 'pry-byebug'
-  s.add_development_dependency 'govuk-lint'
 end

--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -38,7 +38,6 @@ library for use in the UK Government Single Domain project'
   s.add_dependency 'nokogiri', '~> 1.5'
   s.add_dependency "sanitize", "~> 4.6"
 
-  s.add_development_dependency 'gem_publisher', '~> 1.1.1'
   s.add_development_dependency 'govuk-lint'
   s.add_development_dependency 'minitest', '~> 5.8.3'
   s.add_development_dependency 'pry-byebug'

--- a/lib/govspeak/blockquote_extra_quote_remover.rb
+++ b/lib/govspeak/blockquote_extra_quote_remover.rb
@@ -1,7 +1,7 @@
 module Govspeak
   module BlockquoteExtraQuoteRemover
-    QUOTE = '"\u201C\u201D\u201E\u201F\u2033\u2036'
-    LINE_BREAK = '\r\n?|\n'
+    QUOTE = '"\u201C\u201D\u201E\u201F\u2033\u2036'.freeze
+    LINE_BREAK = '\r\n?|\n'.freeze
 
     # used to remove quotes from a markdown blockquote, as these will be inserted
     # as part of the rendering
@@ -13,6 +13,7 @@ module Govspeak
     # > test
     def self.remove(source)
       return if source.nil?
+
       source.gsub(/^>[ \t]*[#{QUOTE}]*([^ \t\n].+?)[#{QUOTE}]*[ \t]*(#{LINE_BREAK}?)$/, '> \1\2')
     end
   end

--- a/lib/govspeak/cli.rb
+++ b/lib/govspeak/cli.rb
@@ -47,7 +47,7 @@ module Govspeak
                else
                  command_options.options
                end
-      string ? JSON.load(string) : {}
+      string ? JSON.parse(string) : {}
     end
   end
 end

--- a/lib/govspeak/cli.rb
+++ b/lib/govspeak/cli.rb
@@ -20,6 +20,7 @@ module Govspeak
         command.action do |args, options|
           input = get_input($stdin, args, options)
           raise "Nothing to render. Use --help for assistance" unless input
+
           puts Govspeak::Document.new(input, govspeak_options(options)).to_html
         end
       end
@@ -31,6 +32,7 @@ module Govspeak
     def get_input(stdin, args, options)
       return stdin.read unless stdin.tty?
       return read_file(options.file) if options.file
+
       args.empty? ? nil : args.join(" ")
     end
 
@@ -41,9 +43,9 @@ module Govspeak
 
     def govspeak_options(command_options)
       string = if command_options.options_file
-                read_file(command_options.options_file)
+                 read_file(command_options.options_file)
                else
-                command_options.options
+                 command_options.options
                end
       string ? JSON.load(string) : {}
     end

--- a/lib/govspeak/header_extractor.rb
+++ b/lib/govspeak/header_extractor.rb
@@ -19,12 +19,12 @@ module Govspeak
 
   private
 
-    def id(el)
-      el.attr.fetch('id', generate_id(el.options[:raw_text]))
+    def id(element)
+      element.attr.fetch('id', generate_id(element.options[:raw_text]))
     end
 
-    def build_header(el)
-      Header.new(el.options[:raw_text], el.options[:level], id(el))
+    def build_header(element)
+      Header.new(element.options[:raw_text], element.options[:level], id(element))
     end
 
     def find_headers(parent)

--- a/lib/govspeak/header_extractor.rb
+++ b/lib/govspeak/header_extractor.rb
@@ -18,6 +18,7 @@ module Govspeak
     end
 
   private
+
     def id(el)
       el.attr.fetch('id', generate_id(el.options[:raw_text]))
     end
@@ -35,7 +36,7 @@ module Govspeak
         parent.children.each do |child|
           if child.type == :header
             headers << build_header(child)
-          elsif child.children.size > 0
+          elsif !child.children.empty?
             headers << find_headers(child)
           end
         end

--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -2,7 +2,6 @@ require 'addressable/uri'
 require 'sanitize'
 
 class Govspeak::HtmlSanitizer
-
   class ImageSourceWhitelister
     def initialize(allowed_image_hosts)
       @allowed_image_hosts = allowed_image_hosts
@@ -21,7 +20,8 @@ class Govspeak::HtmlSanitizer
 
   class TableCellTextAlignWhitelister
     def call(sanitize_context)
-      return unless ["td", "th"].include?(sanitize_context[:node_name])
+      return unless %w[td th].include?(sanitize_context[:node_name])
+
       node = sanitize_context[:node]
 
       # Kramdown uses text-align to allow table cells to be aligned
@@ -51,7 +51,7 @@ class Govspeak::HtmlSanitizer
 
   def sanitize_without_images
     config = sanitize_config
-    Sanitize.clean(@dirty_html, Sanitize::Config.merge(config, elements: config[:elements] - ["img"]))
+    Sanitize.clean(@dirty_html, Sanitize::Config.merge(config, elements: config[:elements] - %w[img]))
   end
 
   def button_sanitize_config
@@ -68,8 +68,8 @@ class Govspeak::HtmlSanitizer
       attributes: {
         :all => Sanitize::Config::RELAXED[:attributes][:all] + ["role", "aria-label"],
         "a"  => Sanitize::Config::RELAXED[:attributes]["a"] + button_sanitize_config,
-        "th"  => Sanitize::Config::RELAXED[:attributes]["th"] + ["style"],
-        "td"  => Sanitize::Config::RELAXED[:attributes]["td"] + ["style"],
+        "th"  => Sanitize::Config::RELAXED[:attributes]["th"] + %w[style],
+        "td"  => Sanitize::Config::RELAXED[:attributes]["td"] + %w[style],
       }
     )
   end

--- a/lib/govspeak/kramdown_overrides.rb
+++ b/lib/govspeak/kramdown_overrides.rb
@@ -7,7 +7,7 @@ module Govspeak
     # match Kramdown's internals.
 
     def self.with_kramdown_ordered_lists_disabled
-      original_list_start = list_start 
+      original_list_start = list_start
       redefine_kramdown_const(:LIST_START, list_start_ul)
       list_parser = kramdown_parsers.delete(:list)
       Kramdown::Parser::Kramdown.define_parser(:list, list_start_ul)
@@ -19,6 +19,7 @@ module Govspeak
     end
 
   private
+
     def self.list_start
       Kramdown::Parser::Kramdown::LIST_START
     end

--- a/lib/govspeak/kramdown_overrides.rb
+++ b/lib/govspeak/kramdown_overrides.rb
@@ -18,8 +18,6 @@ module Govspeak
       kramdown_parsers[:list] = list_parser
     end
 
-  private
-
     def self.list_start
       Kramdown::Parser::Kramdown::LIST_START
     end

--- a/lib/govspeak/link_extractor.rb
+++ b/lib/govspeak/link_extractor.rb
@@ -6,7 +6,7 @@ module Govspeak
     end
 
     def call
-      @links ||= extract_links
+      @call ||= extract_links
     end
 
   private

--- a/lib/govspeak/post_processor.rb
+++ b/lib/govspeak/post_processor.rb
@@ -2,35 +2,18 @@ require 'nokogiri'
 
 module Govspeak
   class PostProcessor
-    attr_reader :input
+    @extensions = []
 
-    @@extensions = []
-
-    def initialize(html)
-      @input = html
+    def self.extensions
+      @extensions
     end
-
-    def nokogiri_document
-      doc = Nokogiri::HTML::Document.new
-      doc.encoding = "UTF-8"
-      doc.fragment(input)
-    end
-  private :nokogiri_document
 
     def self.process(html)
       new(html).output
     end
 
     def self.extension(title, &block)
-      @@extensions << [title, block]
-    end
-
-    def output
-      document = nokogiri_document
-      @@extensions.each do |_, block|
-        instance_exec(document, &block)
-      end
-      document.to_html
+      @extensions << [title, block]
     end
 
     extension("add class to last p of blockquote") do |document|
@@ -64,6 +47,29 @@ module Govspeak
             "<\\1>\\2<\\3>"
           )
       end
+    end
+
+    attr_reader :input
+
+    def initialize(html)
+      @input = html
+    end
+
+    def output
+      document = nokogiri_document
+      self.class.extensions.each do |_, block|
+        instance_exec(document, &block)
+      end
+      document.to_html
+    end
+
+
+  private
+
+    def nokogiri_document
+      doc = Nokogiri::HTML::Document.new
+      doc.encoding = "UTF-8"
+      doc.fragment(input)
     end
   end
 end

--- a/lib/govspeak/post_processor.rb
+++ b/lib/govspeak/post_processor.rb
@@ -15,7 +15,7 @@ module Govspeak
       doc.encoding = "UTF-8"
       doc.fragment(input)
     end
-    private :nokogiri_document
+  private :nokogiri_document
 
     def self.process(html)
       new(html).output
@@ -53,6 +53,7 @@ module Govspeak
       document.css("figure.image").map do |el|
         xml = el.children.to_s
         next unless xml =~ /&lt;div class="img"&gt;|&lt;figcaption&gt;/
+
         el.children = xml
           .gsub(
             %r{&lt;(div class="img")&gt;(.*?)&lt;(/div)&gt;},

--- a/lib/govspeak/presenters/attachment_presenter.rb
+++ b/lib/govspeak/presenters/attachment_presenter.rb
@@ -36,6 +36,7 @@ module Govspeak
 
     def price
       return unless attachment[:price]
+
       Money.from_amount(attachment[:price], 'GBP').format
     end
 
@@ -46,6 +47,7 @@ module Govspeak
     def thumbnail_link
       return if hide_thumbnail?
       return if previewable?
+
       link(attachment_thumbnail, url, "aria-hidden" => "true", "class" => attachment_class)
     end
 
@@ -83,16 +85,16 @@ module Govspeak
     end
 
     def body_for_mail(attachment_info)
-      <<-END
-Details of document required:
+      <<~END
+        Details of document required:
 
-#{attachment_info.join("\n")}
+        #{attachment_info.join("\n")}
 
-Please tell us:
+        Please tell us:
 
-  1. What makes this format unsuitable for you?
-  2. What format you would prefer?
-END
+          1. What makes this format unsuitable for you?
+          2. What format you would prefer?
+      END
     end
 
     def alternative_format_contact_email
@@ -256,6 +258,7 @@ END
 
     def attachment_details
       return if previewable?
+
       link(title, url, title_link_options)
     end
 

--- a/lib/govspeak/presenters/attachment_presenter.rb
+++ b/lib/govspeak/presenters/attachment_presenter.rb
@@ -85,7 +85,7 @@ module Govspeak
     end
 
     def body_for_mail(attachment_info)
-      <<~END
+      <<~TEXT
         Details of document required:
 
         #{attachment_info.join("\n")}
@@ -94,7 +94,7 @@ module Govspeak
 
           1. What makes this format unsuitable for you?
           2. What format you would prefer?
-      END
+      TEXT
     end
 
     def alternative_format_contact_email

--- a/lib/govspeak/presenters/attachment_presenter.rb
+++ b/lib/govspeak/presenters/attachment_presenter.rb
@@ -2,6 +2,8 @@ require "action_view"
 require "money"
 require "htmlentities"
 
+Money.locale_backend = :currency
+
 module Govspeak
   class AttachmentPresenter
     attr_reader :attachment

--- a/lib/govspeak/structured_header_extractor.rb
+++ b/lib/govspeak/structured_header_extractor.rb
@@ -1,5 +1,4 @@
 module Govspeak
-
   StructuredHeader = Struct.new(:text, :level, :id, :headers) do
     def top_level
       2

--- a/lib/kramdown/parser/kramdown_with_automatic_external_links.rb
+++ b/lib/kramdown/parser/kramdown_with_automatic_external_links.rb
@@ -9,12 +9,12 @@ module Kramdown
       end
     end
 
-    define(:document_domains, Object, %w{www.gov.uk}, <<~EOF) do |val|
+    define(:document_domains, Object, %w{www.gov.uk}, <<~DESCRIPTION) do |val|
       Defines the domains which are considered local to the document
 
       Default: www.gov.uk
       Used by: KramdownWithAutomaticExternalLinks
-    EOF
+    DESCRIPTION
       simple_array_validator(val, :document_domains, AlwaysEqual.new)
     end
   end
@@ -26,16 +26,18 @@ module Kramdown
         super
       end
 
-      def add_link(el, href, title, alt_text = nil, ial = nil)
-        if el.type == :a
+      def add_link(element, href, title, alt_text = nil, ial = nil)
+        if element.type == :a
           begin
             host = Addressable::URI.parse(href).host
             unless host.nil? || @document_domains.compact.include?(host)
-              el.attr['rel'] = 'external'
+              element.attr['rel'] = 'external'
             end
+          # rubocop:disable Lint/HandleExceptions
           rescue Addressable::URI::InvalidURIError
             # it's safe to ignore these very *specific* exceptions
           end
+          # rubocop:enable Lint/HandleExceptions
         end
         super
       end

--- a/lib/kramdown/parser/kramdown_with_automatic_external_links.rb
+++ b/lib/kramdown/parser/kramdown_with_automatic_external_links.rb
@@ -4,17 +4,17 @@ require "kramdown/options"
 module Kramdown
   module Options
     class AlwaysEqual
-      def ==(other)
+      def ==(_other)
         true
       end
     end
 
-    define(:document_domains, Object, %w{www.gov.uk}, <<EOF) do |val|
-Defines the domains which are considered local to the document
+    define(:document_domains, Object, %w{www.gov.uk}, <<~EOF) do |val|
+      Defines the domains which are considered local to the document
 
-Default: www.gov.uk
-Used by: KramdownWithAutomaticExternalLinks
-EOF
+      Default: www.gov.uk
+      Used by: KramdownWithAutomaticExternalLinks
+    EOF
       simple_array_validator(val, :document_domains, AlwaysEqual.new)
     end
   end
@@ -30,7 +30,7 @@ EOF
         if el.type == :a
           begin
             host = Addressable::URI.parse(href).host
-            unless host.nil? || (@document_domains.compact.include?(host))
+            unless host.nil? || @document_domains.compact.include?(host)
               el.attr['rel'] = 'external'
             end
           rescue Addressable::URI::InvalidURIError

--- a/test/govspeak_attachments_test.rb
+++ b/test/govspeak_attachments_test.rb
@@ -344,59 +344,6 @@ class GovspeakAttachmentTest < Minitest::Test
     end
   end
 
-  test "a full attachment rendering looks correct" do
-    attachment = {
-      id: 123,
-      content_id: "2b4d92f3-f8cd-4284-aaaa-25b3a640d26c",
-      title: "Attachment Title",
-      url: "http://example.com/test.pdf",
-      opendocument?: true,
-      order_url: "http://example.com/order",
-      price: 12.3,
-      isbn: "isbn-123",
-      unnumbered_command_paper?: true,
-    }
-    rendered = render_govspeak(
-      "[embed:attachments:2b4d92f3-f8cd-4284-aaaa-25b3a640d26c]",
-      [build_attachment(attachment)]
-    )
-    expected_html_output = %{
-      <section class="attachment embedded">
-        <div class="attachment-thumb">
-          <a href="http://example.com/test.pdf" aria-hidden="true" class="embedded"><img src="/images/pub-cover.png" alt="Pub cover"></a>
-        </div>
-        <div class="attachment-details">
-          <h2 class="title">
-            <a href="http://example.com/test.pdf" aria-describedby="attachment-123-accessibility-help">Attachment Title</a>
-          </h2>
-          <p class="metadata">
-            <span class="references">Ref: ISBN <span class="isbn">isbn-123</span></span>
-            <span class="unnumbered-paper">
-              Unnumbered command paper
-            </span>
-          </p>
-          <p>
-            <a href="http://example.com/order" class="order_url" title="Order a copy of the publication">Order a copy</a>(<span class="price">£12.30</span>)
-          </p>
-          <p class="opendocument-help">
-            This file is in an <a rel="external" href="https://en.wikipedia.org/wiki/OpenDocument_software">OpenDocument</a> format
-          </p>
-          <div data-module="toggle" class="accessibility-warning" id="attachment-123-accessibility-help">
-            <h2>This file may not be suitable for users of assistive technology.
-              <a class="toggler" href="#attachment-123-accessibility-request" data-controls="attachment-123-accessibility-request" data-expanded="false">Request an accessible format.</a>
-            </h2>
-            <p id="attachment-123-accessibility-request" class="js-hidden">
-              If you use assistive technology (eg a screen reader) and need a
-              version of this document in a more accessible format, please email <a href="mailto:govuk-feedback@digital.cabinet-office.gov.uk?subject=Request%20for%20%27Attachment%20Title%27%20in%20an%20alternative%20format&amp;body=Details%20of%20document%20required%3A%0A%0A%20%20Title%3A%20Attachment%20Title%0A%20%20ISBN%3A%20isbn-123%0A%0APlease%20tell%20us%3A%0A%0A%20%201.%20What%20makes%20this%20format%20unsuitable%20for%20you%3F%0A%20%202.%20What%20format%20you%20would%20prefer%3F%0A">govuk-feedback@digital.cabinet-office.gov.uk</a>.
-              Please tell us what format you need. It will help us if you say what assistive technology you use.
-            </p>
-          </div>
-        </div>
-      </section>
-    }
-    assert_equal(compress_html(expected_html_output), compress_html(rendered))
-  end
-
   test "attachment that isn't provided" do
     govspeak = "[embed:attachments:906ac8b7-850d-45c6-98e0-9525c680f891]"
     rendered = Govspeak::Document.new(govspeak).to_html

--- a/test/govspeak_contacts_test.rb
+++ b/test/govspeak_contacts_test.rb
@@ -3,8 +3,7 @@
 require 'test_helper'
 
 class GovspeakContactsTest < Minitest::Test
-
-  def build_contact(attrs={})
+  def build_contact(attrs = {})
     {
       id: attrs.fetch(:id, 123456),
       content_id: attrs.fetch(:content_id, "4f3383e4-48a2-4461-a41d-f85ea8b89ba0"),
@@ -25,14 +24,14 @@ class GovspeakContactsTest < Minitest::Test
   end
 
   def compress_html(html)
-    html.gsub(/[\n\r]+[\s]*/,'')
+    html.gsub(/[\n\r]+[\s]*/, '')
   end
 
   test "contact is rendered when present in options[:contacts]" do
     contact = build_contact
     govspeak = "[Contact:4f3383e4-48a2-4461-a41d-f85ea8b89ba0]"
 
-    rendered = Govspeak::Document.new(govspeak, { contacts: [contact] }).to_html
+    rendered = Govspeak::Document.new(govspeak, contacts: [contact]).to_html
     expected_html_output = %{
       <div id="contact_123456" class="contact postal-address">
         <div class="content">
@@ -65,7 +64,7 @@ class GovspeakContactsTest < Minitest::Test
   test "no contact is rendered when contact not present in options[:contacts]" do
     contact = build_contact(content_id: "19f06142-1b4a-47ce-b257-964badd0a5e2")
     govspeak = "[Contact:4f3383e4-48a2-4461-a41d-f85ea8b89ba0]"
-    rendered = Govspeak::Document.new(govspeak, { contacts: [contact]}).to_html
+    rendered = Govspeak::Document.new(govspeak, contacts: [contact]).to_html
     assert_match("", rendered)
   end
 
@@ -83,7 +82,7 @@ class GovspeakContactsTest < Minitest::Test
       postal_code: nil,
     )
     govspeak = "[Contact:4f3383e4-48a2-4461-a41d-f85ea8b89ba0]"
-    rendered = Govspeak::Document.new(govspeak, { contacts: [contact] }).to_html
+    rendered = Govspeak::Document.new(govspeak, contacts: [contact]).to_html
     expected_html_output = %{
       <div id="contact_123456" class="contact">
         <div class="content">
@@ -109,8 +108,8 @@ class GovspeakContactsTest < Minitest::Test
   test "worldwide office contact renders worldwide organisation link" do
     contact = build_contact(worldwide_organisation_path: "/government/world/organisations/british-antarctic-territory")
     govspeak = "[Contact:4f3383e4-48a2-4461-a41d-f85ea8b89ba0]"
-    rendered = Govspeak::Document.new(govspeak, { contacts: [contact] }).to_html
-    organisation_link = %Q(<a href="/government/world/organisations/british-antarctic-territory">Access and opening times</a>)
+    rendered = Govspeak::Document.new(govspeak, contacts: [contact]).to_html
+    organisation_link = %(<a href="/government/world/organisations/british-antarctic-territory">Access and opening times</a>)
     assert_match(organisation_link, rendered)
   end
 end

--- a/test/govspeak_link_extractor_test.rb
+++ b/test/govspeak_link_extractor_test.rb
@@ -45,7 +45,7 @@ class GovspeakLinkExtractorTest < Minitest::Test
   end
 
   test "Other content is not extracted from the body" do
-    refute_includes ["Heading"], links
+    refute_includes %w[Heading], links
   end
 
   test "Links are not extracted if they begin with #" do

--- a/test/govspeak_structured_headers_test.rb
+++ b/test/govspeak_structured_headers_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class GovspeakStructuredHeadersTest < Minitest::Test
-
   def document_body
     %{
 ## Heading 1
@@ -46,7 +45,7 @@ class GovspeakStructuredHeadersTest < Minitest::Test
   end
 
   test "h2s are extracted as top level headings" do
-    expected_headings =  ["Heading 1", "Heading 2", "Heading 3", "Heading 4", "Heading 5"]
+    expected_headings = ["Heading 1", "Heading 2", "Heading 3", "Heading 4", "Heading 5"]
 
     assert_equal expected_headings, structured_headers.map(&:text)
   end
@@ -72,33 +71,33 @@ class GovspeakStructuredHeadersTest < Minitest::Test
     serialized_headers = structured_headers[1].to_h
 
     expected_serialized_headers = {
-      :text => "Heading 2",
-      :level => 2,
-      :id => "heading-2",
-      :headers =>  [
+      text: "Heading 2",
+      level: 2,
+      id: "heading-2",
+      headers: [
         {
-          :text => "Sub heading 2.1",
-          :level => 3,
-          :id => "sub-heading-21",
-          :headers => [],
+          text: "Sub heading 2.1",
+          level: 3,
+          id: "sub-heading-21",
+          headers: [],
         },
         {
-          :text => "Sub heading 2.2",
-          :level => 3,
-          :id => "sub-heading-22",
-          :headers =>  [
+          text: "Sub heading 2.2",
+          level: 3,
+          id: "sub-heading-22",
+          headers: [
             {
-              :text => "Sub sub heading 2.2.1",
-              :level => 4,
-              :id => "sub-sub-heading-221",
-              :headers => []
+              text: "Sub sub heading 2.2.1",
+              level: 4,
+              id: "sub-sub-heading-221",
+              headers: []
             },
           ],
         },
         {
-          :text => "Sub heading 2.3",
-          :level => 3, :id=>"sub-heading-23",
-          :headers => []
+          text: "Sub heading 2.3",
+          level: 3, id: "sub-heading-23",
+          headers: []
         },
       ],
     }

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -9,27 +9,27 @@ class GovspeakTest < Minitest::Test
   include GovspeakTestHelper
 
   test "simple smoke-test" do
-    rendered =  Govspeak::Document.new("*this is markdown*").to_html
+    rendered = Govspeak::Document.new("*this is markdown*").to_html
     assert_equal "<p><em>this is markdown</em></p>\n", rendered
   end
 
   test "simple smoke-test for simplified API" do
-    rendered =  Govspeak::Document.to_html("*this is markdown*")
+    rendered = Govspeak::Document.to_html("*this is markdown*")
     assert_equal "<p><em>this is markdown</em></p>\n", rendered
   end
 
   test "highlight-answer block extension" do
-    rendered =  Govspeak::Document.new("this \n{::highlight-answer}Lead in to *BIG TEXT*\n{:/highlight-answer}").to_html
-    assert_equal %Q{<p>this</p>\n\n<div class="highlight-answer">\n<p>Lead in to <em>BIG TEXT</em></p>\n</div>\n}, rendered
+    rendered = Govspeak::Document.new("this \n{::highlight-answer}Lead in to *BIG TEXT*\n{:/highlight-answer}").to_html
+    assert_equal %{<p>this</p>\n\n<div class="highlight-answer">\n<p>Lead in to <em>BIG TEXT</em></p>\n</div>\n}, rendered
   end
 
   test "stat-headline block extension" do
-    rendered =  Govspeak::Document.new("this \n{stat-headline}*13.8bn* Age of the universe in years{/stat-headline}").to_html
-    assert_equal %Q{<p>this</p>\n\n<aside class="stat-headline">\n<p><em>13.8bn</em> Age of the universe in years</p>\n</aside>\n}, rendered
+    rendered = Govspeak::Document.new("this \n{stat-headline}*13.8bn* Age of the universe in years{/stat-headline}").to_html
+    assert_equal %{<p>this</p>\n\n<aside class="stat-headline">\n<p><em>13.8bn</em> Age of the universe in years</p>\n</aside>\n}, rendered
   end
 
   test "extracts headers with text, level and generated id" do
-    document =  Govspeak::Document.new %{
+    document = Govspeak::Document.new %{
 # Big title
 
 ### Small subtitle
@@ -44,7 +44,7 @@ class GovspeakTest < Minitest::Test
   end
 
   test "extracts different ids for duplicate headers" do
-    document =  Govspeak::Document.new("## Duplicate header\n\n## Duplicate header")
+    document = Govspeak::Document.new("## Duplicate header\n\n## Duplicate header")
     assert_equal [
       Govspeak::Header.new('Duplicate header', 2, 'duplicate-header'),
       Govspeak::Header.new('Duplicate header', 2, 'duplicate-header-1')
@@ -52,7 +52,7 @@ class GovspeakTest < Minitest::Test
   end
 
   test "extracts headers when nested inside blocks" do
-    document =  Govspeak::Document.new %{
+    document = Govspeak::Document.new %{
 # First title
 
 <div markdown="1">
@@ -77,7 +77,7 @@ class GovspeakTest < Minitest::Test
   end
 
   test "extracts headers with explicitly specified ids" do
-    document =  Govspeak::Document.new %{
+    document = Govspeak::Document.new %{
 # First title
 
 ## Second title {#special}
@@ -105,22 +105,22 @@ Teston
   end
 
   test "should convert barchart" do
-    input = <<-END
-|col|
-|---|
-|val|
-{barchart}
+    input = <<~END
+      |col|
+      |---|
+      |val|
+      {barchart}
     END
     html = Govspeak::Document.new(input).to_html
     assert_equal %{<table class=\"js-barchart-table mc-auto-outdent\">\n  <thead>\n    <tr>\n      <th>col</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td>val</td>\n    </tr>\n  </tbody>\n</table>\n}, html
   end
 
   test "should convert barchart with stacked compact and negative" do
-    input = <<-END
-|col|
-|---|
-|val|
-{barchart stacked compact negative}
+    input = <<~END
+      |col|
+      |---|
+      |val|
+      {barchart stacked compact negative}
     END
     html = Govspeak::Document.new(input).to_html
     assert_equal %{<table class=\"js-barchart-table mc-stacked compact mc-negative mc-auto-outdent\">\n  <thead>\n    <tr>\n      <th>col</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td>val</td>\n    </tr>\n  </tbody>\n</table>\n}, html
@@ -331,17 +331,17 @@ Teston
   test "should treat a mailto as internal" do
     html = Govspeak::Document.new("[link](mailto:a@b.com)").to_html
     refute html.include?('rel="external"')
-    assert_equal %Q{<p><a href="mailto:a@b.com">link</a></p>\n}, deobfuscate_mailto(html)
+    assert_equal %{<p><a href="mailto:a@b.com">link</a></p>\n}, deobfuscate_mailto(html)
   end
 
   test "permits mailto:// URI" do
     html = Govspeak::Document.new("[link](mailto://a@b.com)").to_html
-    assert_equal %Q{<p><a rel="external" href="mailto://a@b.com">link</a></p>\n}, deobfuscate_mailto(html)
+    assert_equal %{<p><a rel="external" href="mailto://a@b.com">link</a></p>\n}, deobfuscate_mailto(html)
   end
 
   test "permits dud mailto: URI" do
     html = Govspeak::Document.new("[link](mailto:)").to_html
-    assert_equal %Q{<p><a href="mailto:">link</a></p>\n}, deobfuscate_mailto(html)
+    assert_equal %{<p><a href="mailto:">link</a></p>\n}, deobfuscate_mailto(html)
   end
 
   test "permits trailing whitespace in an URI" do
@@ -421,7 +421,6 @@ Teston
   end
 
   test_given_govspeak "Here is some text
-
 $CTA
 Click here to start the tool
 $CTA
@@ -639,17 +638,17 @@ $CTA
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>} +
         %{</figure>}
       )
+    end
   end
-end
 
-test "alt text of referenced images is escaped" do
-  images = [OpenStruct.new(alt_text: %Q{my alt '&"<>}, url: "http://example.com/image.jpg")]
-  given_govspeak "!!1", images do
-    assert_html_output(
-      %{<figure class="image embedded">} +
-      %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt '&amp;&quot;&lt;&gt;"></div>} +
-      %{</figure>}
-    )
+  test "alt text of referenced images is escaped" do
+    images = [OpenStruct.new(alt_text: %{my alt '&"<>}, url: "http://example.com/image.jpg")]
+    given_govspeak "!!1", images do
+      assert_html_output(
+        %{<figure class="image embedded">} +
+        %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt '&amp;&quot;&lt;&gt;"></div>} +
+        %{</figure>}
+      )
     end
   end
 
@@ -657,7 +656,7 @@ test "alt text of referenced images is escaped" do
     doc = Govspeak::Document.new("!!1")
     doc.images = []
 
-    assert_equal %Q{\n}, doc.to_html
+    assert_equal %{\n}, doc.to_html
   end
 
   test "adds image caption if given" do
@@ -838,7 +837,7 @@ $PriorityList:1
   end
 
   test "should remove quotes surrounding a blockquote" do
-    govspeak = %Q{
+    govspeak = %{
 He said:
 
 > "I'm not sure what you mean!"

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -105,23 +105,23 @@ Teston
   end
 
   test "should convert barchart" do
-    input = <<~END
+    input = <<~GOVSPEAK
       |col|
       |---|
       |val|
       {barchart}
-    END
+    GOVSPEAK
     html = Govspeak::Document.new(input).to_html
     assert_equal %{<table class=\"js-barchart-table mc-auto-outdent\">\n  <thead>\n    <tr>\n      <th>col</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td>val</td>\n    </tr>\n  </tbody>\n</table>\n}, html
   end
 
   test "should convert barchart with stacked compact and negative" do
-    input = <<~END
+    input = <<~GOVSPEAK
       |col|
       |---|
       |val|
       {barchart stacked compact negative}
-    END
+    GOVSPEAK
     html = Govspeak::Document.new(input).to_html
     assert_equal %{<table class=\"js-barchart-table mc-stacked compact mc-negative mc-auto-outdent\">\n  <thead>\n    <tr>\n      <th>col</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td>val</td>\n    </tr>\n  </tbody>\n</table>\n}, html
   end
@@ -420,10 +420,12 @@ Teston
     assert_text_output "Click here to start the tool"
   end
 
-  test_given_govspeak "Here is some text
-$CTA
-Click here to start the tool
-$CTA
+  test_given_govspeak "
+    Here is some text
+
+    $CTA
+    Click here to start the tool
+    $CTA
     " do
     assert_html_output %{
       <p>Here is some text</p>

--- a/test/govspeak_test_helper.rb
+++ b/test/govspeak_test_helper.rb
@@ -1,5 +1,4 @@
 module GovspeakTestHelper
-
   def self.included(base)
     base.extend(ClassMethods)
   end
@@ -13,7 +12,7 @@ module GovspeakTestHelper
     end
 
     def document
-      Govspeak::Document.new(@govspeak, @options.merge(:images => @images))
+      Govspeak::Document.new(@govspeak, @options.merge(images: @images))
     end
 
     def assert_text_output(raw_expected)
@@ -53,12 +52,12 @@ module GovspeakTestHelper
       lines = text.split "\n"
       digits = Math.log10(lines.size + 2).ceil
       lines.map.with_index do |line, i|
-        "%#{digits}d: %s" % [i+1, line]
+        "%#{digits}d: %s" % [i + 1, line]
       end.join "\n"
     end
   end
 
-  def given_govspeak(govspeak, images=[], options = {}, &block)
+  def given_govspeak(govspeak, images = [], options = {}, &block)
     asserter = GovspeakAsserter.new(self, govspeak, images, options)
     asserter.instance_eval(&block)
   end
@@ -72,7 +71,7 @@ module GovspeakTestHelper
   end
 
   module ClassMethods
-    def test_given_govspeak(govspeak, images=[], options = {}, &block)
+    def test_given_govspeak(govspeak, images = [], options = {}, &block)
       test "Given #{govspeak}" do
         given_govspeak(govspeak, images, options, &block)
       end

--- a/test/govspeak_test_helper.rb
+++ b/test/govspeak_test_helper.rb
@@ -32,9 +32,7 @@ module GovspeakTestHelper
       if lines.first.empty?
         lines.delete_at(0)
         nonblanks = lines.reject { |l| l.match(/^ *$/) }
-        indentation = nonblanks.map do |line|
-          line.match(/^ */)[0].size
-        end.min
+        indentation = nonblanks.map { |line| line.match(/^ */)[0].size }.min
         unindented = lines.map do |line|
           line[indentation..-1]
         end
@@ -51,9 +49,9 @@ module GovspeakTestHelper
     def show_linenumbers(text)
       lines = text.split "\n"
       digits = Math.log10(lines.size + 2).ceil
-      lines.map.with_index do |line, i|
-        "%#{digits}d: %s" % [i + 1, line]
-      end.join "\n"
+      lines.map
+        .with_index { |line, i| "%<number>#{digits}d: %<line>s" % { number: i + 1, line: line } }
+        .join("\n")
     end
   end
 

--- a/test/html_sanitizer_test.rb
+++ b/test/html_sanitizer_test.rb
@@ -1,15 +1,14 @@
 require "test_helper"
 
 class HtmlSanitizerTest < Minitest::Test
-
   test "disallow a script tag" do
     html = "<script>alert('XSS')</script>"
     assert_equal "alert('XSS')", Govspeak::HtmlSanitizer.new(html).sanitize
   end
 
   test "disallow a javascript protocol in an attribute" do
-    html = %q{<a href="javascript:alert(document.location);"
-              title="Title">an example</a>}
+    html = '<a href="javascript:alert(document.location);"
+              title="Title">an example</a>'
     assert_equal "<a title=\"Title\">an example</a>", Govspeak::HtmlSanitizer.new(html).sanitize
   end
 
@@ -69,7 +68,7 @@ class HtmlSanitizerTest < Minitest::Test
 
 
   test "allows valid text-align properties on the style attribute for table cells and table headings" do
-    ["left", "right", "center"].each do |alignment|
+    %w[left right center].each do |alignment|
       html = "<table><thead><tr><th style=\"text-align: #{alignment}\">thing</th></tr></thead><tbody><tr><td style=\"text-align: #{alignment}\">thing</td></tr></tbody></table>"
       assert_equal html, Govspeak::HtmlSanitizer.new(html).sanitize
     end

--- a/test/html_validator_test.rb
+++ b/test/html_validator_test.rb
@@ -63,13 +63,13 @@ class HtmlValidatorTest < Minitest::Test
   end
 
   test "disallow a javascript protocol in an attribute" do
-    html = %q{<a href="javascript:alert(document.location);"
-              title="Title">an example</a>}
+    html = '<a href="javascript:alert(document.location);"
+              title="Title">an example</a>'
     assert Govspeak::HtmlValidator.new(html).invalid?
   end
 
   test "disallow a javascript protocol in a Markdown link" do
-    html = %q{This is [an example](javascript:alert(""); "Title") inline link.}
+    html = 'This is [an example](javascript:alert(""); "Title") inline link.'
     assert Govspeak::HtmlValidator.new(html).invalid?
   end
 

--- a/test/html_validator_test.rb
+++ b/test/html_validator_test.rb
@@ -11,11 +11,11 @@ class HtmlValidatorTest < Minitest::Test
       "+ another bullet",
       "1. Numbered list",
       "s2. Step",
-      """
+      "
       Table | Header
       - | -
       Build | cells
-      """,
+      ",
       "This is [an example](/an-inline-link \"Title\") inline link.",
       "<http://example.com/>",
       "<address@example.com>",
@@ -34,7 +34,7 @@ class HtmlValidatorTest < Minitest::Test
       "{:/highlight-answer}",
       "---",
       "*[GDS]: Government Digital Service",
-      """
+      "
       $P
 
       $I
@@ -49,7 +49,7 @@ class HtmlValidatorTest < Minitest::Test
       $AI
       $I
       $P
-      """,
+      ",
       ":england:content goes here:england:",
       ":scotland:content goes here:scotland:"
     ]

--- a/test/presenters/h_card_presenter_test.rb
+++ b/test/presenters/h_card_presenter_test.rb
@@ -4,7 +4,6 @@ require 'test_helper'
 require 'ostruct'
 
 class HCardPresenterTest < Minitest::Test
-
   def unindent(html)
     html.gsub(/^\s+/, '')
   end
@@ -88,8 +87,7 @@ class HCardPresenterTest < Minitest::Test
       'postal-code' => 'Postcode',
       'locality' => 'Locality',
       'region' => 'Region',
-      'country-name' => 'Country'
-    }
+      'country-name' => 'Country' }
   end
 
   def gb_addr

--- a/test/presenters/h_card_presenter_test.rb
+++ b/test/presenters/h_card_presenter_test.rb
@@ -91,7 +91,7 @@ class HCardPresenterTest < Minitest::Test
   end
 
   def gb_addr
-    <<-EOF
+    <<-HTML
     <p class="adr">
     <span class="fn">Recipient</span><br />
     <span class="street-address">Street</span><br />
@@ -100,33 +100,33 @@ class HCardPresenterTest < Minitest::Test
     <span class="postal-code">Postcode</span><br />
     <span class="country-name">Country</span>
     </p>
-    EOF
+    HTML
   end
 
   def es_addr
-    <<-EOF
+    <<-HTML
     <p class="adr">
     <span class="fn">Recipient</span><br />
     <span class="street-address">Street</span><br />
     <span class="postal-code">Postcode</span> <span class="locality">Locality</span> <span class="region">Region</span><br />
     <span class="country-name">Country</span>
     </p>
-    EOF
+    HTML
   end
 
   def jp_addr
-    <<-EOF
+    <<-HTML
     <p class="adr">
     〒<span class="postal-code">Postcode</span><br />
     <span class="region">Region</span><span class="locality">Locality</span><span class="street-address">Street</span><br />
     <span class="fn">Recipient</span><br />
     <span class="country-name">Country</span>
     </p>
-    EOF
+    HTML
   end
 
   def addr_without_region
-    <<-EOF
+    <<-HTML
     <p class="adr">
     <span class="fn">Recipient</span><br />
     <span class="street-address">Street</span><br />
@@ -134,11 +134,11 @@ class HCardPresenterTest < Minitest::Test
     <span class="postal-code">Postcode</span><br />
     <span class="country-name">Country</span>
     </p>
-    EOF
+    HTML
   end
 
   def addr_without_country
-    <<-EOF
+    <<-HTML
     <p class="adr">
     <span class="fn">Recipient</span><br />
     <span class="street-address">Street</span><br />
@@ -146,6 +146,6 @@ class HCardPresenterTest < Minitest::Test
     <span class="region">Region</span><br />
     <span class="postal-code">Postcode</span>
     </p>
-    EOF
+    HTML
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,11 +14,12 @@ require 'minitest/autorun'
 class Minitest::Test
   class << self
     def test(name, &block)
-     clean_name = name.gsub(/\s+/,'_')
-     method = "test_#{clean_name.gsub(/\s+/,'_')}".to_sym
-     already_defined = instance_method(method) rescue false
-     raise "#{method} exists" if already_defined
-     define_method(method, &block)
+      clean_name = name.gsub(/\s+/, '_')
+      method = "test_#{clean_name.gsub(/\s+/, '_')}".to_sym
+      already_defined = instance_method(method) rescue false
+      raise "#{method} exists" if already_defined
+
+      define_method(method, &block)
     end
   end
 end


### PR DESCRIPTION
Loosely related trello: https://trello.com/c/gEAMmD0g/386-ability-to-embed-a-contact-via-markdown

As there hasn't been active development on this gem for a while it's pretty out of date with other GOV.UK gems.

I've updated this so:

- There aren't any linting issues
- Use `govuk.buildProject` to build it (which now tests it against rubies 2.3, 2.4 and 2.5 rather than 2.1, 2.2 and 2.3)
- Drop support for Rails 4
- Remove an unreliable test that produces different results based on ActiveSupport version
- Stop getting deprecation warnings when using Money gem