### PR TITLE
Add supporting files to the gemspec

### DIFF
--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -18,6 +18,9 @@ library for use in the UK Government Single Domain project'
   s.files         = Dir[
     'bin/*',
     'lib/**/*',
+    'assets/*',
+    'config/*',
+    'locales/*',
     'README.md',
     'CHANGELOG.md',
     'Gemfile',


### PR DESCRIPTION
Trello: https://trello.com/c/gEAMmD0g/386-ability-to-embed-a-contact-via-markdown

Turns out the files for translations and config aren't being bundled as
part of the gem. This adds them in so that features like attachment and
contacts are usable.