### PR TITLE
New image extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,36 @@ will output a image section
 </figure>
 ```
 
+### Images
+
+Images can be embedded as a figure with optional caption.
+
+    [Image:filename.png]
+
+with options provided
+
+    {
+      images: [
+        {
+          alt_text: "Some alt text",
+          caption: "An optional caption",
+          url: "http://example.com/lovely-landscape.jpg",
+          id: "filename.png",
+        }
+      ]
+    }
+
+will output a image section
+
+```html
+<figure class="image embedded">
+  <div class="img">
+    <img src="http://example.com/lovely-landscape.jpg" alt="Some alt text">
+    <figcaption>An optional caption</figcaption>
+  </div>
+</figure>
+```
+
 ### Link
 
 Links to different documents can be embedded so they change when the documents

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ will output an attachment within a block of text
 <p>Details referenced in <span class="attachment-inline"><a href="http://example.com/my-thorough-study.pdf">My Thorough Study</a></span></p>
 ```
 
-### Image Attachments
+### Image Attachments (DEPRECATED: use `Image:image-id` instead)
 
 Attachments can be used to embed an image within the document
 

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -355,7 +355,7 @@ module Govspeak
     end
 
     extension('Image', /\[Image:\s*(.*?)\s*\]/) do |image_id|
-      image = images.detect { |c| c[:id] == image_id }
+      image = images.detect { |c| c.is_a?(Hash) && c[:id] == image_id }
       next "" unless image
       render_image(ImagePresenter.new(image))
     end

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -246,6 +246,7 @@ module Govspeak
       %{<span#{span_id} class="attachment-inline">#{link}#{attributes}</span>}
     end
 
+    # DEPRECATED: use 'Image:image-id' instead
     extension('attachment image', /\[embed:attachments:image:\s*(.*?)\s*\]/) do |content_id|
       attachment = attachments.detect { |a| a[:content_id] == content_id }
       next "" unless attachment

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -266,7 +266,7 @@ module Govspeak
       lines = []
       lines << %{<figure#{id_attr} class="image embedded">}
       lines << %{<div class="img"><img src="#{encode(image.url)}" alt="#{encode(image.alt_text)}"></div>}
-      lines << %{<figcaption>#{image.caption}</figcaption>} if image.caption
+      lines << %{<figcaption>#{encode(image.caption)}</figcaption>} if image.caption
       lines << '</figure>'
       lines.join
     end

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -354,6 +354,12 @@ module Govspeak
       @renderer.result(binding)
     end
 
+    extension('Image', /\[Image:\s*(.*?)\s*\]/) do |image_id|
+      image = images.detect { |c| c[:id] == image_id }
+      next "" unless image
+      render_image(ImagePresenter.new(image))
+    end
+
   private
 
     def kramdown_doc

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -220,6 +220,7 @@ module Govspeak
     extension('attached-image', /^!!([0-9]+)/) do |image_number|
       image = images[image_number.to_i - 1]
       next "" unless image
+
       render_image(ImagePresenter.new(image))
     end
 
@@ -248,6 +249,7 @@ module Govspeak
     extension('attachment image', /\[embed:attachments:image:\s*(.*?)\s*\]/) do |content_id|
       attachment = attachments.detect { |a| a[:content_id] == content_id }
       next "" unless attachment
+
       render_image(AttachmentImagePresenter.new(attachment))
     end
 
@@ -357,6 +359,7 @@ module Govspeak
     extension('Image', /\[Image:\s*(.*?)\s*\]/) do |image_id|
       image = images.detect { |c| c.is_a?(Hash) && c[:id] == image_id }
       next "" unless image
+
       render_image(ImagePresenter.new(image))
     end
 

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -16,6 +16,8 @@ require 'govspeak/link_extractor'
 require 'govspeak/presenters/attachment_presenter'
 require 'govspeak/presenters/contact_presenter'
 require 'govspeak/presenters/h_card_presenter'
+require 'govspeak/presenters/image_presenter'
+require 'govspeak/presenters/attachment_image_presenter'
 
 
 module Govspeak
@@ -217,12 +219,8 @@ module Govspeak
 
     extension('attached-image', /^!!([0-9]+)/) do |image_number|
       image = images[image_number.to_i - 1]
-      if image
-        caption = image.caption rescue nil
-        render_image(image.url, image.alt_text, caption)
-      else
-        ""
-      end
+      next "" unless image
+      render_image(ImagePresenter.new(image))
     end
 
     extension('attachment', /\[embed:attachments:(?!inline:|image:)\s*(.*?)\s*\]/) do |content_id, body|
@@ -250,10 +248,7 @@ module Govspeak
     extension('attachment image', /\[embed:attachments:image:\s*(.*?)\s*\]/) do |content_id|
       attachment = attachments.detect { |a| a[:content_id] == content_id }
       next "" unless attachment
-
-      attachment = AttachmentPresenter.new(attachment)
-      title = (attachment.title || "").tr("\n", " ")
-      render_image(attachment.url, title, nil, attachment.id)
+      render_image(AttachmentImagePresenter.new(attachment))
     end
 
     # As of version 1.12.0 of Kramdown the block elements (div & figcaption)
@@ -266,12 +261,12 @@ module Govspeak
     # out div and figcaption
     #
     # This issue is not considered a bug by kramdown: https://github.com/gettalong/kramdown/issues/191
-    def render_image(url, alt_text, caption = nil, id = nil)
-      id_attr = id ? %{ id="attachment_#{id}"} : ""
+    def render_image(image)
+      id_attr = image.id ? %{ id="attachment_#{image.id}"} : ""
       lines = []
       lines << %{<figure#{id_attr} class="image embedded">}
-      lines << %{<div class="img"><img src="#{encode(url)}" alt="#{encode(alt_text)}"></div>}
-      lines << %{<figcaption>#{caption.strip}</figcaption>} if caption && !caption.strip.empty?
+      lines << %{<div class="img"><img src="#{encode(image.url)}" alt="#{encode(image.alt_text)}"></div>}
+      lines << %{<figcaption>#{image.caption}</figcaption>} if image.caption
       lines << '</figure>'
       lines.join
     end

--- a/lib/govspeak/presenters/attachment_image_presenter.rb
+++ b/lib/govspeak/presenters/attachment_image_presenter.rb
@@ -1,0 +1,25 @@
+module Govspeak
+  class AttachmentImagePresenter
+    attr_reader :attachment
+
+    def initialize(attachment)
+      @attachment = AttachmentPresenter.new(attachment)
+    end
+
+    def url
+      attachment.url
+    end
+
+    def alt_text
+      (attachment.title || "").tr("\n", " ")
+    end
+
+    def caption
+      nil
+    end
+
+    def id
+      attachment.id
+    end
+  end
+end

--- a/lib/govspeak/presenters/image_presenter.rb
+++ b/lib/govspeak/presenters/image_presenter.rb
@@ -7,15 +7,15 @@ module Govspeak
     end
 
     def url
-      image.url
+      image[:url]
     end
 
     def alt_text
-      image.alt_text
+      image[:alt_text]
     end
 
     def caption
-      image.caption.strip.presence rescue nil
+      image[:caption].to_s.strip.presence
     end
 
     def id

--- a/lib/govspeak/presenters/image_presenter.rb
+++ b/lib/govspeak/presenters/image_presenter.rb
@@ -1,0 +1,25 @@
+module Govspeak
+  class ImagePresenter
+    attr_reader :image
+
+    def initialize(image)
+      @image = image
+    end
+
+    def url
+      image.url
+    end
+
+    def alt_text
+      image.alt_text
+    end
+
+    def caption
+      image.caption.strip.presence rescue nil
+    end
+
+    def id
+      nil
+    end
+  end
+end

--- a/lib/govspeak/presenters/image_presenter.rb
+++ b/lib/govspeak/presenters/image_presenter.rb
@@ -7,15 +7,15 @@ module Govspeak
     end
 
     def url
-      image[:url]
+      image.respond_to?(:url) ? image.url : image[:url]
     end
 
     def alt_text
-      image[:alt_text]
+      image.respond_to?(:alt_text) ? image.alt_text : image[:alt_text]
     end
 
     def caption
-      image[:caption].to_s.strip.presence
+      (image.respond_to?(:caption) ? image.caption : image[:caption]).to_s.strip.presence
     end
 
     def id

--- a/test/govspeak_images_bang_test.rb
+++ b/test/govspeak_images_bang_test.rb
@@ -6,14 +6,18 @@ require 'govspeak_test_helper'
 class GovspeakImagesBangTest < Minitest::Test
   include GovspeakTestHelper
 
-  def build_image(attrs = {})
-    attrs[:alt_text] ||= "my alt"
-    attrs[:url] ||= "http://example.com/image.jpg"
-    OpenStruct.new(attrs)
+  class Image
+    attr_reader :alt_text, :url, :caption
+
+    def initialize(attrs = {})
+      @alt_text = attrs[:alt_text] || "my alt"
+      @url = attrs[:url] || "http://example.com/image.jpg"
+      @caption = attrs[:caption]
+    end
   end
 
   test "!!n syntax renders an image in options[:images]" do
-    given_govspeak "!!1", images: [build_image] do
+    given_govspeak "!!1", images: [Image.new] do
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>} +
@@ -23,7 +27,7 @@ class GovspeakImagesBangTest < Minitest::Test
   end
 
   test "!!n syntax escapes alt text" do
-    given_govspeak "!!1", images: [build_image(alt_text: %{my alt '&"<>})] do
+    given_govspeak "!!1", images: [Image.new(alt_text: %{my alt '&"<>})] do
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt '&amp;&quot;&lt;&gt;"></div>} +
@@ -37,8 +41,13 @@ class GovspeakImagesBangTest < Minitest::Test
     assert_equal %{\n}, doc.to_html
   end
 
+  test "Image:image-id syntax renders nothing" do
+    doc = Govspeak::Document.new("[Image:another-id]", images: [Image.new])
+    assert_equal %{\n}, doc.to_html
+  end
+
   test "!!n syntax adds image caption if given" do
-    given_govspeak "!!1", images: [build_image(caption: 'My Caption & so on')] do
+    given_govspeak "!!1", images: [Image.new(caption: 'My Caption & so on')] do
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>\n} +
@@ -49,7 +58,7 @@ class GovspeakImagesBangTest < Minitest::Test
   end
 
   test "!!n syntax ignores a blank caption" do
-    given_govspeak "!!1", images: [build_image(caption: '  ')] do
+    given_govspeak "!!1", images: [Image.new(caption: '  ')] do
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>} +

--- a/test/govspeak_images_bang_test.rb
+++ b/test/govspeak_images_bang_test.rb
@@ -3,13 +3,12 @@
 require 'test_helper'
 require 'govspeak_test_helper'
 
-class GovspeakImages!!Test < Minitest::Test
+class GovspeakImagesBangTest < Minitest::Test
   include GovspeakTestHelper
 
   def build_image(attrs = {})
     attrs[:alt_text] ||= "my alt"
     attrs[:url] ||= "http://example.com/image.jpg"
-    attrs[:caption] ||= "   "
     OpenStruct.new(attrs)
   end
 

--- a/test/govspeak_images_test.rb
+++ b/test/govspeak_images_test.rb
@@ -1,0 +1,60 @@
+# encoding: UTF-8
+
+require 'test_helper'
+require 'govspeak_test_helper'
+
+class GovspeakImagesTest < Minitest::Test
+  include GovspeakTestHelper
+
+  test "can reference attached images using !!n" do
+    images = [OpenStruct.new(alt_text: 'my alt', url: "http://example.com/image.jpg")]
+    given_govspeak "!!1", images do
+      assert_html_output(
+        %{<figure class="image embedded">} +
+        %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>} +
+        %{</figure>}
+      )
+    end
+  end
+
+  test "alt text of referenced images is escaped" do
+    images = [OpenStruct.new(alt_text: %{my alt '&"<>}, url: "http://example.com/image.jpg")]
+    given_govspeak "!!1", images do
+      assert_html_output(
+        %{<figure class="image embedded">} +
+        %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt '&amp;&quot;&lt;&gt;"></div>} +
+        %{</figure>}
+      )
+    end
+  end
+
+  test "silently ignores an image attachment if the referenced image is missing" do
+    doc = Govspeak::Document.new("!!1")
+    doc.images = []
+
+    assert_equal %{\n}, doc.to_html
+  end
+
+  test "adds image caption if given" do
+    images = [OpenStruct.new(alt_text: "my alt", url: "http://example.com/image.jpg", caption: 'My Caption & so on')]
+    given_govspeak "!!1", images do
+      assert_html_output(
+        %{<figure class="image embedded">} +
+        %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>\n} +
+        %{<figcaption>My Caption &amp; so on</figcaption>} +
+        %{</figure>}
+      )
+    end
+  end
+
+  test "ignores a blank caption" do
+    images = [OpenStruct.new(alt_text: "my alt", url: "http://example.com/image.jpg", caption: '  ')]
+    given_govspeak "!!1", images do
+      assert_html_output(
+        %{<figure class="image embedded">} +
+        %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>} +
+        %{</figure>}
+      )
+    end
+  end
+end

--- a/test/govspeak_images_test.rb
+++ b/test/govspeak_images_test.rb
@@ -3,18 +3,18 @@
 require 'test_helper'
 require 'govspeak_test_helper'
 
-class GovspeakImages!!Test < Minitest::Test
+class GovspeakImagesTest < Minitest::Test
   include GovspeakTestHelper
 
   def build_image(attrs = {})
     attrs[:alt_text] ||= "my alt"
     attrs[:url] ||= "http://example.com/image.jpg"
-    attrs[:caption] ||= "   "
-    OpenStruct.new(attrs)
+    attrs[:id] ||= "image-id"
+    attrs
   end
 
-  test "!!n syntax renders an image in options[:images]" do
-    given_govspeak "!!1", images: [build_image] do
+  test "Image:image-id syntax renders an image in options[:images]" do
+    given_govspeak "[Image:image-id]", images: [build_image] do
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>} +
@@ -23,8 +23,8 @@ class GovspeakImages!!Test < Minitest::Test
     end
   end
 
-  test "!!n syntax escapes alt text" do
-    given_govspeak "!!1", images: [build_image(alt_text: %{my alt '&"<>})] do
+  test "Image:image-id syntax escapes alt text" do
+    given_govspeak "[Image:image-id]", images: [build_image(alt_text: %{my alt '&"<>})] do
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt '&amp;&quot;&lt;&gt;"></div>} +
@@ -33,13 +33,13 @@ class GovspeakImages!!Test < Minitest::Test
     end
   end
 
-  test "!!n syntax renders nothing if not found" do
-    doc = Govspeak::Document.new("!!1")
+  test "Image:image-id syntax renders nothing if not found" do
+    doc = Govspeak::Document.new("[Image:another-id]")
     assert_equal %{\n}, doc.to_html
   end
 
-  test "!!n syntax adds image caption if given" do
-    given_govspeak "!!1", images: [build_image(caption: 'My Caption & so on')] do
+  test "Image:image-id syntax adds image caption if given" do
+    given_govspeak "[Image:image-id]", images: [build_image(caption: 'My Caption & so on')] do
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>\n} +
@@ -49,8 +49,8 @@ class GovspeakImages!!Test < Minitest::Test
     end
   end
 
-  test "!!n syntax ignores a blank caption" do
-    given_govspeak "!!1", images: [build_image(caption: '  ')] do
+  test "Image:image-id syntax ignores a blank caption" do
+    given_govspeak "[Image:image-id]", images: [build_image(caption: '  ')] do
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>} +

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -440,7 +440,7 @@ Teston
 
     $CTA
     Click here to start the tool
-    $CTA", [], document_domains: %w(www.not-external.com) do
+    $CTA", document_domains: %w(www.not-external.com) do
     assert_html_output %{
       <p><a href="http://www.not-external.com">internal link</a></p>
 

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -632,58 +632,6 @@ Teston
       }
   end
 
-  test "can reference attached images using !!n" do
-    images = [OpenStruct.new(alt_text: 'my alt', url: "http://example.com/image.jpg")]
-    given_govspeak "!!1", images do
-      assert_html_output(
-        %{<figure class="image embedded">} +
-        %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>} +
-        %{</figure>}
-      )
-    end
-  end
-
-  test "alt text of referenced images is escaped" do
-    images = [OpenStruct.new(alt_text: %{my alt '&"<>}, url: "http://example.com/image.jpg")]
-    given_govspeak "!!1", images do
-      assert_html_output(
-        %{<figure class="image embedded">} +
-        %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt '&amp;&quot;&lt;&gt;"></div>} +
-        %{</figure>}
-      )
-    end
-  end
-
-  test "silently ignores an image attachment if the referenced image is missing" do
-    doc = Govspeak::Document.new("!!1")
-    doc.images = []
-
-    assert_equal %{\n}, doc.to_html
-  end
-
-  test "adds image caption if given" do
-    images = [OpenStruct.new(alt_text: "my alt", url: "http://example.com/image.jpg", caption: 'My Caption & so on')]
-    given_govspeak "!!1", images do
-      assert_html_output(
-        %{<figure class="image embedded">} +
-        %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>\n} +
-        %{<figcaption>My Caption &amp; so on</figcaption>} +
-        %{</figure>}
-      )
-    end
-  end
-
-  test "ignores a blank caption" do
-    images = [OpenStruct.new(alt_text: "my alt", url: "http://example.com/image.jpg", caption: '  ')]
-    given_govspeak "!!1", images do
-      assert_html_output(
-        %{<figure class="image embedded">} +
-        %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>} +
-        %{</figure>}
-      )
-    end
-  end
-
   test "can sanitize a document" do
     document = Govspeak::Document.new("<script>doBadThings();</script>")
     assert_equal "doBadThings();", document.to_sanitized_html.strip

--- a/test/govspeak_test_helper.rb
+++ b/test/govspeak_test_helper.rb
@@ -4,15 +4,14 @@ module GovspeakTestHelper
   end
 
   class GovspeakAsserter
-    def initialize(testcase, govspeak, images = [], options = {})
+    def initialize(testcase, govspeak, options = {})
       @testcase = testcase
       @govspeak = remove_indentation(govspeak)
-      @images = images
       @options = options
     end
 
     def document
-      Govspeak::Document.new(@govspeak, @options.merge(images: @images))
+      Govspeak::Document.new(@govspeak, @options)
     end
 
     def assert_text_output(raw_expected)
@@ -55,8 +54,8 @@ module GovspeakTestHelper
     end
   end
 
-  def given_govspeak(govspeak, images = [], options = {}, &block)
-    asserter = GovspeakAsserter.new(self, govspeak, images, options)
+  def given_govspeak(govspeak, options = {}, &block)
+    asserter = GovspeakAsserter.new(self, govspeak, options)
     asserter.instance_eval(&block)
   end
 
@@ -69,9 +68,9 @@ module GovspeakTestHelper
   end
 
   module ClassMethods
-    def test_given_govspeak(govspeak, images = [], options = {}, &block)
+    def test_given_govspeak(govspeak, options = {}, &block)
       test "Given #{govspeak}" do
-        given_govspeak(govspeak, images, options, &block)
+        given_govspeak(govspeak, options, &block)
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/9MSu3fpP/532-add-support-for-imagefilenamepng-to-govspeak

This adds support for a [Image:image-id] syntax to deprecate the old !!n syntax, both of which make use of an 'images' array but expect different data structures:

   * The old data structure is a method with :url, :alt_text and :caption methods
   * The new data structure is a hash with :url, :alt_text, :caption and :id keys

Using the old syntax with the new data structure will work, while using the new syntax with the old data structure will not. Any form of ID can be used for the new data structure, although a filename is recommended for readability.