### PR TITLE
Bump version to 5.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.8.0
+
+* Add new `Image:image-id` extension and deprecate `embed:attachments:image:content-id`
+
 ## 5.7.1
 
 * Include locale, config and asset files in the gem distribution

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "5.7.1".freeze
+  VERSION = "5.8.0".freeze
 end


### PR DESCRIPTION
https://trello.com/c/9MSu3fpP/532-add-support-for-imagefilenamepng-to-govspeak