### PR TITLE
Show image credit on inline images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Add image credits to embedded images
+
 ## 5.8.0
 
 * Add new `Image:image-id` extension and deprecate `embed:attachments:image:content-id`

--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ with options provided
         {
           alt_text: "Some alt text",
           caption: "An optional caption",
+          credit: "An optional credit",
           url: "http://example.com/lovely-landscape.jpg",
           id: "filename.png",
         }
@@ -485,7 +486,10 @@ will output a image section
 <figure class="image embedded">
   <div class="img">
     <img src="http://example.com/lovely-landscape.jpg" alt="Some alt text">
-    <figcaption>An optional caption</figcaption>
+    <figcaption>
+      <p>An optional caption</p>
+      <p>Image credit: An optional credit</p>
+    </figcaption>
   </div>
 </figure>
 ```

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -271,7 +271,7 @@ module Govspeak
       lines << %{<div class="img"><img src="#{encode(image.url)}" alt="#{encode(image.alt_text)}"></div>}
       lines << '<figcaption>' if image.figcaption?
       lines << %{<p>#{encode(image.caption)}</p>} if image.caption.present?
-      lines << %{<p>#{encode(image.credit)}</p>} if image.credit.present?
+      lines << %{<p>#{encode(t('govspeak.image.figure.credit', credit: image.credit))}</p>} if image.credit.present?
       lines << '</figcaption>' if image.figcaption?
       lines << '</figure>'
       lines.join

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -271,6 +271,7 @@ module Govspeak
       lines << %{<div class="img"><img src="#{encode(image.url)}" alt="#{encode(image.alt_text)}"></div>}
       lines << '<figcaption>' if image.figcaption?
       lines << %{#{encode(image.caption)}} if image.caption.present?
+      lines << %{#{encode(image.credit)}} if image.credit.present?
       lines << '</figcaption>' if image.figcaption?
       lines << '</figure>'
       lines.join

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -269,7 +269,9 @@ module Govspeak
       lines = []
       lines << %{<figure#{id_attr} class="image embedded">}
       lines << %{<div class="img"><img src="#{encode(image.url)}" alt="#{encode(image.alt_text)}"></div>}
-      lines << %{<figcaption>#{encode(image.caption)}</figcaption>} if image.caption
+      lines << '<figcaption>' if image.figcaption?
+      lines << %{#{encode(image.caption)}} if image.caption.present?
+      lines << '</figcaption>' if image.figcaption?
       lines << '</figure>'
       lines.join
     end

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -269,10 +269,7 @@ module Govspeak
       lines = []
       lines << %{<figure#{id_attr} class="image embedded">}
       lines << %{<div class="img"><img src="#{encode(image.url)}" alt="#{encode(image.alt_text)}"></div>}
-      lines << '<figcaption>' if image.figcaption?
-      lines << %{<p>#{encode(image.caption)}</p>} if image.caption.present?
-      lines << %{<p>#{encode(t('govspeak.image.figure.credit', credit: image.credit))}</p>} if image.credit.present?
-      lines << '</figcaption>' if image.figcaption?
+      lines << image.figcaption_html if image.figcaption?
       lines << '</figure>'
       lines.join
     end

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -270,8 +270,8 @@ module Govspeak
       lines << %{<figure#{id_attr} class="image embedded">}
       lines << %{<div class="img"><img src="#{encode(image.url)}" alt="#{encode(image.alt_text)}"></div>}
       lines << '<figcaption>' if image.figcaption?
-      lines << %{#{encode(image.caption)}} if image.caption.present?
-      lines << %{#{encode(image.credit)}} if image.credit.present?
+      lines << %{<p>#{encode(image.caption)}</p>} if image.caption.present?
+      lines << %{<p>#{encode(image.credit)}</p>} if image.credit.present?
       lines << '</figcaption>' if image.figcaption?
       lines << '</figure>'
       lines.join

--- a/lib/govspeak/presenters/attachment_image_presenter.rb
+++ b/lib/govspeak/presenters/attachment_image_presenter.rb
@@ -29,5 +29,9 @@ module Govspeak
     def figcaption?
       false
     end
+
+    def figcaption_html
+      nil
+    end
   end
 end

--- a/lib/govspeak/presenters/attachment_image_presenter.rb
+++ b/lib/govspeak/presenters/attachment_image_presenter.rb
@@ -18,6 +18,10 @@ module Govspeak
       nil
     end
 
+    def credit
+      nil
+    end
+
     def id
       attachment.id
     end

--- a/lib/govspeak/presenters/attachment_image_presenter.rb
+++ b/lib/govspeak/presenters/attachment_image_presenter.rb
@@ -21,5 +21,9 @@ module Govspeak
     def id
       attachment.id
     end
+
+    def figcaption?
+      false
+    end
   end
 end

--- a/lib/govspeak/presenters/image_presenter.rb
+++ b/lib/govspeak/presenters/image_presenter.rb
@@ -29,5 +29,14 @@ module Govspeak
     def figcaption?
       caption.present? || credit.present?
     end
+
+    def figcaption_html
+      lines = []
+      lines << '<figcaption>'
+      lines << %{<p>#{caption}</p>} if caption.present?
+      lines << %{<p>#{I18n.t('govspeak.image.figure.credit', credit: credit)}</p>} if credit.present?
+      lines << '</figcaption>'
+      lines.join
+    end
   end
 end

--- a/lib/govspeak/presenters/image_presenter.rb
+++ b/lib/govspeak/presenters/image_presenter.rb
@@ -18,12 +18,16 @@ module Govspeak
       (image.respond_to?(:caption) ? image.caption : image[:caption]).to_s.strip.presence
     end
 
+    def credit
+      (image.respond_to?(:credit) ? image.credit : image[:credit]).to_s.strip.presence
+    end
+
     def id
       nil
     end
 
     def figcaption?
-      caption.present?
+      caption.present? || credit.present?
     end
   end
 end

--- a/lib/govspeak/presenters/image_presenter.rb
+++ b/lib/govspeak/presenters/image_presenter.rb
@@ -21,5 +21,9 @@ module Govspeak
     def id
       nil
     end
+
+    def figcaption?
+      caption.present?
+    end
   end
 end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -24,3 +24,6 @@ en:
     contact:
       email: Email
       contact_form: Contact form
+    image:
+      figure:
+        credit: "Image credit: %{credit}"

--- a/test/govspeak_images_bang_test.rb
+++ b/test/govspeak_images_bang_test.rb
@@ -73,7 +73,7 @@ class GovspeakImagesBangTest < Minitest::Test
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>\n} +
-        %{<figcaption><p>My Credit &amp; so on</p></figcaption>} +
+        %{<figcaption><p>Image credit: My Credit &amp; so on</p></figcaption>} +
         %{</figure>}
       )
     end
@@ -96,7 +96,7 @@ class GovspeakImagesBangTest < Minitest::Test
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>\n} +
         %{<figcaption>} +
           %{<p>My Caption &amp; so on</p>\n} +
-          %{<p>My Credit &amp; so on</p>} +
+          %{<p>Image credit: My Credit &amp; so on</p>} +
         %{</figcaption>} +
         %{</figure>}
       )

--- a/test/govspeak_images_bang_test.rb
+++ b/test/govspeak_images_bang_test.rb
@@ -52,7 +52,7 @@ class GovspeakImagesBangTest < Minitest::Test
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>\n} +
-        %{<figcaption>My Caption &amp; so on</figcaption>} +
+        %{<figcaption><p>My Caption &amp; so on</p></figcaption>} +
         %{</figure>}
       )
     end
@@ -73,7 +73,7 @@ class GovspeakImagesBangTest < Minitest::Test
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>\n} +
-        %{<figcaption>My Credit &amp; so on</figcaption>} +
+        %{<figcaption><p>My Credit &amp; so on</p></figcaption>} +
         %{</figure>}
       )
     end
@@ -84,6 +84,20 @@ class GovspeakImagesBangTest < Minitest::Test
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>} +
+        %{</figure>}
+      )
+    end
+  end
+
+  test "!!n syntax adds image caption and credit if given" do
+    given_govspeak "!!1", images: [Image.new(caption: 'My Caption & so on', credit: 'My Credit & so on')] do
+      assert_html_output(
+        %{<figure class="image embedded">} +
+        %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>\n} +
+        %{<figcaption>} +
+          %{<p>My Caption &amp; so on</p>\n} +
+          %{<p>My Credit &amp; so on</p>} +
+        %{</figcaption>} +
         %{</figure>}
       )
     end

--- a/test/govspeak_images_bang_test.rb
+++ b/test/govspeak_images_bang_test.rb
@@ -7,12 +7,13 @@ class GovspeakImagesBangTest < Minitest::Test
   include GovspeakTestHelper
 
   class Image
-    attr_reader :alt_text, :url, :caption
+    attr_reader :alt_text, :url, :caption, :credit
 
     def initialize(attrs = {})
       @alt_text = attrs[:alt_text] || "my alt"
       @url = attrs[:url] || "http://example.com/image.jpg"
       @caption = attrs[:caption]
+      @credit = attrs[:credit]
     end
   end
 
@@ -59,6 +60,27 @@ class GovspeakImagesBangTest < Minitest::Test
 
   test "!!n syntax ignores a blank caption" do
     given_govspeak "!!1", images: [Image.new(caption: '  ')] do
+      assert_html_output(
+        %{<figure class="image embedded">} +
+        %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>} +
+        %{</figure>}
+      )
+    end
+  end
+
+  test "¡¡n syntax adds image credit if given" do
+    given_govspeak "!!1", images: [Image.new(credit: 'My Credit & so on')] do
+      assert_html_output(
+        %{<figure class="image embedded">} +
+        %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>\n} +
+        %{<figcaption>My Credit &amp; so on</figcaption>} +
+        %{</figure>}
+      )
+    end
+  end
+
+  test "!!n syntax ignores a blank credit" do
+    given_govspeak "!!1", images: [Image.new(credit: '  ')] do
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>} +

--- a/test/govspeak_images_test.rb
+++ b/test/govspeak_images_test.rb
@@ -43,7 +43,7 @@ class GovspeakImagesTest < Minitest::Test
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>\n} +
-        %{<figcaption>My Caption &amp; so on</figcaption>} +
+        %{<figcaption><p>My Caption &amp; so on</p></figcaption>} +
         %{</figure>}
       )
     end
@@ -64,7 +64,7 @@ class GovspeakImagesTest < Minitest::Test
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>\n} +
-        %{<figcaption>My Credit &amp; so on</figcaption>} +
+        %{<figcaption><p>My Credit &amp; so on</p></figcaption>} +
         %{</figure>}
       )
     end
@@ -75,6 +75,20 @@ class GovspeakImagesTest < Minitest::Test
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>} +
+        %{</figure>}
+      )
+    end
+  end
+
+  test "Image:image-id syntax adds image caption and credit if given" do
+    given_govspeak "[Image:image-id]", images: [build_image(caption: 'My Caption & so on', credit: 'My Credit & so on')] do
+      assert_html_output(
+        %{<figure class="image embedded">} +
+        %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>\n} +
+        %{<figcaption>} +
+          %{<p>My Caption &amp; so on</p>\n} +
+          %{<p>My Credit &amp; so on</p>} +
+        %{</figcaption>} +
         %{</figure>}
       )
     end

--- a/test/govspeak_images_test.rb
+++ b/test/govspeak_images_test.rb
@@ -58,4 +58,25 @@ class GovspeakImagesTest < Minitest::Test
       )
     end
   end
+
+  test "Image:image-id syntax adds image credit if given" do
+    given_govspeak "[Image:image-id]", images: [build_image(credit: 'My Credit & so on')] do
+      assert_html_output(
+        %{<figure class="image embedded">} +
+        %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>\n} +
+        %{<figcaption>My Credit &amp; so on</figcaption>} +
+        %{</figure>}
+      )
+    end
+  end
+
+  test "Image:image-id syntax ignores a blank credit" do
+    given_govspeak "[Image:image-id]", images: [build_image(credit: '  ')] do
+      assert_html_output(
+        %{<figure class="image embedded">} +
+        %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>} +
+        %{</figure>}
+      )
+    end
+  end
 end

--- a/test/govspeak_images_test.rb
+++ b/test/govspeak_images_test.rb
@@ -64,7 +64,7 @@ class GovspeakImagesTest < Minitest::Test
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>\n} +
-        %{<figcaption><p>My Credit &amp; so on</p></figcaption>} +
+        %{<figcaption><p>Image credit: My Credit &amp; so on</p></figcaption>} +
         %{</figure>}
       )
     end
@@ -87,7 +87,7 @@ class GovspeakImagesTest < Minitest::Test
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>\n} +
         %{<figcaption>} +
           %{<p>My Caption &amp; so on</p>\n} +
-          %{<p>My Credit &amp; so on</p>} +
+          %{<p>Image credit: My Credit &amp; so on</p>} +
         %{</figcaption>} +
         %{</figure>}
       )


### PR DESCRIPTION
Trello: 
* https://trello.com/c/VLAns9Hq
* https://trello.com/c/b0VF9sdO

## Motivation
Content publisher allows publishers to add an image credit for images they upload. Images in content publisher are being extended to allow publishers to add inline images, which will also allow an image credit.

Updates the govspeak gem so that image credits are rendered when users preview their content.
