### PR TITLE
Don't render [Image: <file>] that is within a paragraph

### DIFF
--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -29,6 +29,7 @@ module Govspeak
     Parser = Kramdown::Parser::KramdownWithAutomaticExternalLinks
     PARSER_CLASS_NAME = Parser.name.split("::").last
     UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.freeze
+    NEW_PARAGRAPH_LOOKBEHIND = %q{(?<=\A|\n\n|\r\n\r\n)}.freeze
 
     @extensions = []
 
@@ -287,7 +288,7 @@ module Govspeak
       %{\n<div class="address"><div class="adr org fn"><p>\n#{body.sub("\n", '').gsub("\n", '<br />')}\n</p></div></div>\n}
     }
 
-    extension("legislative list", /(?<=\A|\n\n|\r\n\r\n)^\$LegislativeList\s*$(.*?)\$EndLegislativeList/m) do |body|
+    extension("legislative list", /#{NEW_PARAGRAPH_LOOKBEHIND}\$LegislativeList\s*$(.*?)\$EndLegislativeList/m) do |body|
       Govspeak::KramdownOverrides.with_kramdown_ordered_lists_disabled do
         Kramdown::Document.new(body.strip).to_html.tap do |doc|
           doc.gsub!('<ul>', '<ol>')
@@ -324,7 +325,7 @@ module Govspeak
       end
     end
 
-    extension("Priority list", /(?<=\A|\n\n|\r\n\r\n)^\$PriorityList:(\d+)\s*$(.*?)(?:^\s*$|\Z)/m) do |number_to_show, body|
+    extension("Priority list", /#{NEW_PARAGRAPH_LOOKBEHIND}\$PriorityList:(\d+)\s*$(.*?)(?:^\s*$|\Z)/m) do |number_to_show, body|
       number_to_show = number_to_show.to_i
       tagged = 0
       Govspeak::Document.new(body.strip).to_html.gsub(/<li>/) do |match|

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -358,7 +358,7 @@ module Govspeak
       @renderer.result(binding)
     end
 
-    extension('Image', /\[Image:\s*(.*?)\s*\]/) do |image_id|
+    extension('Image', /#{NEW_PARAGRAPH_LOOKBEHIND}\[Image:\s*(.*?)\s*\]/) do |image_id|
       image = images.detect { |c| c.is_a?(Hash) && c[:id] == image_id }
       next "" unless image
 

--- a/test/govspeak_images_test.rb
+++ b/test/govspeak_images_test.rb
@@ -93,4 +93,27 @@ class GovspeakImagesTest < Minitest::Test
       )
     end
   end
+
+  test "Image is not inserted when it does not start on a new line" do
+    given_govspeak "some text [Image:image-id]", images: [build_image] do
+      assert_html_output("<p>some text [Image:image-id]</p>")
+    end
+
+    given_govspeak "[Image:image-id]", images: [build_image] do
+      assert_html_output(
+        %{<figure class="image embedded">} +
+        %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>} +
+        %{</figure>}
+      )
+    end
+
+    given_govspeak "[Image:image-id] some text", images: [build_image] do
+      assert_html_output(
+        %{<figure class="image embedded">} +
+        %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>} +
+        %{</figure>\n} +
+        %{<p>some text</p>}
+      )
+    end
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/MkWywL4g/590-support-inline-images

Doing this causes invalid HTML (it embeds elements such as figure, div
and p) and undesirable visual presentation - raw HTML is output.

Since this tag is not used in the wild just yet, it can be fixed before
users make use of it.

These same problems apply to the other Image embeds however I dare not
change those in case there are places where users are relying on the
invalid HTML is produced and it breaks documents.