### PR TITLE
Sanitize input by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* BREAKING CHANGE: Input is sanitized by default, to use unsafe HTML initialize with a sanitize option of false
 * Allow sanitize option on remove invalid HTML from source input
 * BREAKING CHANGE: Remove `to_sanitized_html` method in favour of `sanitize` option on initialize
 * BREAKING CHANGE: Remove `to_sanitized_html_without_images` as no apps use this anymore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 * Allow sanitize option on remove invalid HTML from source input
+* BREAKING CHANGE: Remove `to_sanitized_html` method in favour of `sanitize` option on initialize
+* BREAKING CHANGE: Remove `to_sanitized_html_without_images` as no apps use this anymore
 
 ## 5.9.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Allow sanitize option on remove invalid HTML from source input
+
 ## 5.9.1
 
 * Don't render `[Image: {file-name}]` within a paragraph to avoid invalid HTML

--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -40,7 +40,7 @@ library for use in the UK Government Single Domain project'
   s.add_dependency 'money', '~> 6.7'
   s.add_dependency 'nokogiri', '~> 1.5'
   s.add_dependency 'rinku', '~> 2.0'
-  s.add_dependency "sanitize", "~> 4.6"
+  s.add_dependency "sanitize", "~> 5"
 
   s.add_development_dependency 'govuk-lint'
   s.add_development_dependency 'minitest', '~> 5.8.3'

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -65,7 +65,7 @@ module Govspeak
     end
 
     def to_html
-      @to_html ||= Govspeak::PostProcessor.process(kramdown_doc.to_html)
+      @to_html ||= Govspeak::PostProcessor.process(kramdown_doc.to_html, self)
     end
 
     def to_liquid
@@ -215,12 +215,11 @@ module Govspeak
       render_image(ImagePresenter.new(image))
     end
 
-    extension('attachment', /\[embed:attachments:(?!inline:|image:)\s*(.*?)\s*\]/) do |content_id, body|
-      attachment = attachments.detect { |a| a[:content_id] == content_id }
-      next "" unless attachment
-
-      renderer = TemplateRenderer.new('attachment.html.erb', locale)
-      renderer.render(attachment: AttachmentPresenter.new(attachment))
+    extension('attachment', /\[embed:attachments:(?!inline:|image:)\s*(.*?)\s*\]/) do |content_id|
+      # not treating this as a self closing tag seems to avoid some oddities
+      # such as an extra new line being inserted when explicitly closed or
+      # swallowing subsequent elements when not closed
+      %{<govspeak-embed-attachment content-id="#{content_id}"></govspeak-embed-attachment>}
     end
 
     extension('attachment inline', /\[embed:attachments:inline:\s*(.*?)\s*\]/) do |content_id|

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -81,14 +81,6 @@ module Govspeak
       ERB::Util.html_escape(string || "").strip.gsub(/(?:\r?\n)/, "<br/>").html_safe
     end
 
-    def to_sanitized_html
-      HtmlSanitizer.new(to_html).sanitize
-    end
-
-    def to_sanitized_html_without_images
-      HtmlSanitizer.new(to_html).sanitize_without_images
-    end
-
     def to_text
       HTMLEntities.new.decode(to_html.gsub(/(?:<[^>]+>|\s)+/, " ").strip)
     end

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -46,7 +46,14 @@ module Govspeak
 
     def initialize(source, options = {})
       options = options.dup.deep_symbolize_keys
-      @source = source ? source.dup : ""
+      unsanitized_source = source ? source.dup : ""
+
+      @source = if options[:sanitize]
+                  HtmlSanitizer.new(unsanitized_source).sanitize
+                else
+                  unsanitized_source
+                end
+
       @images = options.delete(:images) || []
       @attachments = Array.wrap(options.delete(:attachments))
       @links = Array.wrap(options.delete(:links))

--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -49,11 +49,6 @@ class Govspeak::HtmlSanitizer
     Sanitize.clean(@dirty_html, Sanitize::Config.merge(sanitize_config, transformers: transformers))
   end
 
-  def sanitize_without_images
-    config = sanitize_config
-    Sanitize.clean(@dirty_html, Sanitize::Config.merge(config, elements: config[:elements] - %w[img]))
-  end
-
   def button_sanitize_config
     [
       "data-module",

--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -60,11 +60,13 @@ class Govspeak::HtmlSanitizer
   def sanitize_config
     Sanitize::Config.merge(
       Sanitize::Config::RELAXED,
+      elements: Sanitize::Config::RELAXED[:elements] + %w[govspeak-embed-attachment],
       attributes: {
         :all => Sanitize::Config::RELAXED[:attributes][:all] + ["role", "aria-label"],
         "a"  => Sanitize::Config::RELAXED[:attributes]["a"] + button_sanitize_config,
         "th"  => Sanitize::Config::RELAXED[:attributes]["th"] + %w[style],
         "td"  => Sanitize::Config::RELAXED[:attributes]["td"] + %w[style],
+        "govspeak-embed-attachment" => %w[content-id],
       }
     )
   end

--- a/lib/govspeak/html_validator.rb
+++ b/lib/govspeak/html_validator.rb
@@ -22,6 +22,6 @@ class Govspeak::HtmlValidator
   end
 
   def govspeak_to_html
-    Govspeak::Document.new(govspeak_string).to_html
+    Govspeak::Document.new(govspeak_string, sanitize: false).to_html
   end
 end

--- a/lib/govspeak/template_renderer.rb
+++ b/lib/govspeak/template_renderer.rb
@@ -1,0 +1,27 @@
+module Govspeak
+  class TemplateRenderer
+    attr_reader :template, :locale
+
+    def initialize(template, locale)
+      @template = template
+      @locale = locale
+    end
+
+    def render(locals)
+      template_binding = binding
+      locals.each { |k, v| template_binding.local_variable_set(k, v) }
+      erb = ERB.new(File.read(__dir__ + "/../templates/#{template}"))
+      erb.result(template_binding)
+    end
+
+    def t(*args)
+      options = args.last.is_a?(Hash) ? args.last.dup : {}
+      key = args.shift
+      I18n.t!(key, options.merge(locale: locale))
+    end
+
+    def format_with_html_line_breaks(string)
+      ERB::Util.html_escape(string || "").strip.gsub(/(?:\r?\n)/, "<br/>").html_safe
+    end
+  end
+end

--- a/lib/templates/contact.html.erb
+++ b/lib/templates/contact.html.erb
@@ -7,7 +7,7 @@
     <h3><%= contact.title %></h3>
     <div class="vcard contact-inner">
     <% contact.post_addresses.each do |address| %>
-      <%= render_hcard_address(address) %>
+      <%= Govspeak::HCardPresenter.new(address).render %>
     <% end %>
     <% if contact.email_addresses.any? || contact.phone_numbers.any? || contact.contact_form_links.any? %>
       <div class="email-url-number">

--- a/lib/templates/inline_attachment.html.erb
+++ b/lib/templates/inline_attachment.html.erb
@@ -1,6 +1,0 @@
-<span <% if attachment.id %>id="attachment_<%= attachment.id %>" <% end %>class="attachment-inline">
-  <%= attachment.link attachment.title, attachment.url %>
-  <% unless attachment.attachment_attributes.empty? %>
-    (<%= attachment.attachment_attributes %>)
-  <% end %>
-</span>

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -632,6 +632,11 @@ Teston
       }
   end
 
+  test 'can sanitize source input' do
+    document = Govspeak::Document.new("<script>doBadThings();</script>", sanitize: true)
+    assert_equal "<p>doBadThings();</p>", document.to_html.strip
+  end
+
   test "can sanitize a document" do
     document = Govspeak::Document.new("<script>doBadThings();</script>")
     assert_equal "doBadThings();", document.to_sanitized_html.strip

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -637,16 +637,6 @@ Teston
     assert_equal "<p>doBadThings();</p>", document.to_html.strip
   end
 
-  test "can sanitize a document" do
-    document = Govspeak::Document.new("<script>doBadThings();</script>")
-    assert_equal "doBadThings();", document.to_sanitized_html.strip
-  end
-
-  test "can sanitize a document without image" do
-    document = Govspeak::Document.new("<script>doBadThings();</script><img src='https://example.com/image.jpg'>")
-    assert_equal "doBadThings();<p></p>", document.to_sanitized_html_without_images.gsub(/\s/, "")
-  end
-
   test "identifies a Govspeak document containing malicious HTML as invalid" do
     document = Govspeak::Document.new("<script>doBadThings();</script>")
     refute document.valid?

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -634,7 +634,7 @@ Teston
 
   test 'can sanitize source input' do
     document = Govspeak::Document.new("<script>doBadThings();</script>", sanitize: true)
-    assert_equal "<p>doBadThings();</p>", document.to_html.strip
+    assert_equal "", document.to_html.strip
   end
 
   test "identifies a Govspeak document containing malicious HTML as invalid" do

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -632,9 +632,14 @@ Teston
       }
   end
 
-  test 'can sanitize source input' do
-    document = Govspeak::Document.new("<script>doBadThings();</script>", sanitize: true)
+  test 'sanitize source input by default' do
+    document = Govspeak::Document.new("<script>doBadThings();</script>")
     assert_equal "", document.to_html.strip
+  end
+
+  test 'it can have sanitizing disabled' do
+    document = Govspeak::Document.new("<script>doGoodThings();</script>", sanitize: false)
+    assert_equal "<script>doGoodThings();</script>", document.to_html.strip
   end
 
   test "identifies a Govspeak document containing malicious HTML as invalid" do

--- a/test/html_sanitizer_test.rb
+++ b/test/html_sanitizer_test.rb
@@ -46,11 +46,6 @@ class HtmlSanitizerTest < Minitest::Test
     assert_equal "", Govspeak::HtmlSanitizer.new(html, allowed_image_hosts: ['allowed.com']).sanitize
   end
 
-  test "can strip images" do
-    html = "<img src='http://example.com/image.jgp'>"
-    assert_equal "", Govspeak::HtmlSanitizer.new(html).sanitize_without_images
-  end
-
   test "allows table cells and table headings without a style attribute" do
     html = "<table><thead><tr><th>thing</th></tr></thead><tbody><tr><td>thing</td></tr></tbody></table>"
     assert_equal html, Govspeak::HtmlSanitizer.new(html).sanitize

--- a/test/html_sanitizer_test.rb
+++ b/test/html_sanitizer_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class HtmlSanitizerTest < Minitest::Test
   test "disallow a script tag" do
     html = "<script>alert('XSS')</script>"
-    assert_equal "alert('XSS')", Govspeak::HtmlSanitizer.new(html).sanitize
+    assert_equal "", Govspeak::HtmlSanitizer.new(html).sanitize
   end
 
   test "disallow a javascript protocol in an attribute" do


### PR DESCRIPTION
Trello: https://trello.com/c/SdMUjUmj/722-resolve-xss-issues-raised-by-pen-testers

This introduces a breaking change to govspeak where sanitization is performed by default on input and the means to turn this off is by passing a `sanitize: false` argument.

This replaces the previous method of sanitization which was to call `to_sanitized_html` on a govspeak document. This was a rather dubious approach as all testing of extensions was done against `to_html` so it was easy for some govspeak extensions to not work against that approach.

I had a ponder and I felt that since most apps use the [`valid?`](https://github.com/alphagov/govspeak/blob/34b2cd789b51ab9ce11cee5a0e8bfe3fac274da4/lib/govspeak.rb#L89) then the effects of turning sanitize on by default should be minimal. Any apps that aren't checking that would likely have security vulnerabilities that this resolves (as well as any pain points this introduces).