### PR TITLE
Iterate blockquote remover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Blockquote quote remover is now more forgiving to spaces before or after quote characters
+
 ## 6.0.0
 
 * BREAKING CHANGE: Input is sanitized by default, to use unsafe HTML initialize with a sanitize option of false

--- a/lib/govspeak/blockquote_extra_quote_remover.rb
+++ b/lib/govspeak/blockquote_extra_quote_remover.rb
@@ -1,7 +1,7 @@
 module Govspeak
   module BlockquoteExtraQuoteRemover
-    QUOTE = '"\u201C\u201D\u201E\u201F\u2033\u2036'.freeze
-    LINE_BREAK = '\r\n?|\n'.freeze
+    QUOTES = '["\u201C\u201D\u201E\u201F\u2033\u2036]+'.freeze
+    WHITESPACE = '[^\S\r\n]*'.freeze
 
     # used to remove quotes from a markdown blockquote, as these will be inserted
     # as part of the rendering
@@ -14,7 +14,8 @@ module Govspeak
     def self.remove(source)
       return if source.nil?
 
-      source.gsub(/^>[ \t]*[#{QUOTE}]*([^ \t\n].+?)[#{QUOTE}]*[ \t]*(#{LINE_BREAK}?)$/, '> \1\2')
+      source.gsub(/^>#{WHITESPACE}#{QUOTES}#{WHITESPACE}(.+?)$/, '> \1') # prefixed with a quote
+            .gsub(/^>(.+?)#{WHITESPACE}#{QUOTES}#{WHITESPACE}(\r?)$/, '>\1\2') # suffixed with a quote
     end
   end
 end

--- a/test/blockquote_extra_quote_remover_test.rb
+++ b/test/blockquote_extra_quote_remover_test.rb
@@ -60,6 +60,13 @@ class BlockquoteExtraQuoteRemoverTest < Minitest::Test
     )
   end
 
+  test "handles space after a quote" do
+    assert_remover_transforms(
+      %{>" Test"} =>
+      %{> Test}
+    )
+  end
+
   test "remove double double quotes" do
     assert_remover_transforms(
       %{We heard it said:\n\n> ""Today the coalition is remedying those deficiencies by putting in place a new fast track process where the people's elected representatives have responsibility for the final decisions about Britain's future instead of unelected commissioners.""} =>


### PR DESCRIPTION
This fixes an issue that was found where a space after the start of a
quote is not matched by the expression.

I switched this to be two regexes that match strings that either start
with a quote or end in a quote. This replaces the optional approach
where either quote is optional and this effectively matched all block
quote strings - this was hard to maintain because it ended up changing
lines with just "> ".