### PR TITLE
Add new, experimental syntaxes for embedding attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Add new `AttachementLink:attachment-id` extension and mark as experimental
 * Add new `Attachement:attachment-id` extension and mark as experimental
 * Blockquote quote remover is now more forgiving to spaces before or after quote characters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Add new `Attachement:attachment-id` extension and mark as experimental
 * Blockquote quote remover is now more forgiving to spaces before or after quote characters
 
 ## 6.0.0

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -217,14 +217,14 @@ module Govspeak
       render_image(ImagePresenter.new(image))
     end
 
-    extension('attachment', /\[embed:attachments:(?!inline:|image:)\s*(.*?)\s*\]/) do |content_id|
+    extension('embed attachment', /\[embed:attachments:(?!inline:|image:)\s*(.*?)\s*\]/) do |content_id|
       # not treating this as a self closing tag seems to avoid some oddities
       # such as an extra new line being inserted when explicitly closed or
       # swallowing subsequent elements when not closed
       %{<govspeak-embed-attachment content-id="#{content_id}"></govspeak-embed-attachment>}
     end
 
-    extension('attachment inline', /\[embed:attachments:inline:\s*(.*?)\s*\]/) do |content_id|
+    extension('embed attachment inline', /\[embed:attachments:inline:\s*(.*?)\s*\]/) do |content_id|
       attachment = attachments.detect { |a| a[:content_id] == content_id }
       next "" unless attachment
 

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -354,6 +354,14 @@ module Govspeak
       render_image(ImagePresenter.new(image))
     end
 
+    # This is an alternative syntax for embedding attachments using a readable id (expected
+    # to be a unique variation of a filename). This syntax is being used by
+    # Content Publisher and should be considered experimental as it is likely
+    # to be iterated in the short term.
+    extension('Attachment', /#{NEW_PARAGRAPH_LOOKBEHIND}\[Attachment:\s*(.*?)\s*\]/) do |attachment_id|
+      %{<govspeak-embed-attachment id="#{attachment_id}"></govspeak-embed-attachment>}
+    end
+
   private
 
     def kramdown_doc

--- a/lib/govspeak/post_processor.rb
+++ b/lib/govspeak/post_processor.rb
@@ -51,7 +51,14 @@ module Govspeak
 
     extension("embed attachment HTML") do |document|
       document.css("govspeak-embed-attachment").map do |el|
-        attachment = govspeak_document.attachments.detect { |a| a[:content_id] == el["content-id"] }
+        attachment = govspeak_document.attachments.detect do |a|
+          if el["id"].present?
+            a[:id] == el["id"]
+          else
+            a[:content_id] == el["content-id"]
+          end
+        end
+
         unless attachment
           el.remove
           next

--- a/test/govspeak_attachments_inline_test.rb
+++ b/test/govspeak_attachments_inline_test.rb
@@ -169,4 +169,12 @@ class GovspeakAttachmentsInlineTest < Minitest::Test
     rendered = render_govspeak("[embed:attachments:inline: path/to/file name.jpg ]")
     assert_equal("\n", rendered)
   end
+
+  test "supports alternative syntax for attachment links" do
+    rendered = render_govspeak(
+      "[AttachmentLink:f.pdf]",
+      [build_attachment(content_id: nil, id: "f.pdf", url: "http://a.b/f.pdf", title: "My Pdf")]
+    )
+    assert_match(%r{<a href="http://a.b/f.pdf">My Pdf</a>}, rendered)
+  end
 end

--- a/test/govspeak_attachments_test.rb
+++ b/test/govspeak_attachments_test.rb
@@ -6,7 +6,7 @@ class GovspeakAttachmentTest < Minitest::Test
   def build_attachment(args = {})
     {
       content_id: "2b4d92f3-f8cd-4284-aaaa-25b3a640d26c",
-      id: 456,
+      id: 'attachment-id',
       url: "http://example.com/attachment.pdf",
       title: "Attachment Title",
     }.merge(args)
@@ -354,5 +354,34 @@ class GovspeakAttachmentTest < Minitest::Test
     govspeak = "[embed:attachments:/path/to/file%20name.pdf]"
     rendered = Govspeak::Document.new(govspeak).to_html
     assert_equal("\n", rendered)
+  end
+
+  test "attachment using [Attachment:id] syntax" do
+    rendered = render_govspeak(
+      "[Attachment:file.png]",
+      [build_attachment(id: "file.png", content_id: nil)]
+    )
+    assert_match(/<section class="attachment embedded">/, rendered)
+  end
+
+  test "attachment using [Attachment:id] syntax is not inserted when it does not start on a new line" do
+    rendered = render_govspeak(
+      "some text [Attachment:file.png]",
+      [build_attachment(id: "file.png")]
+    )
+    assert_equal("<p>some text [Attachment:file.png]</p>\n", rendered)
+
+    rendered = render_govspeak(
+      "[Attachment:file.png]",
+      [build_attachment(id: "file.png")]
+    )
+    assert_match(/<section class="attachment embedded">/, rendered)
+
+    rendered = render_govspeak(
+      "[Attachment:file.png] some text",
+      [build_attachment(id: "file.png")]
+    )
+    assert_match(/<section class="attachment embedded">/, rendered)
+    assert_match(/<p>some text<\/p>/, rendered)
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/3c6nomPo/782-mvp-of-inline-attachment-flow-add-and-insert

This provides two govspeak options for embedding attachments: `[Attachment:file-id]` and `[AttachmentLink:file-id]`. It is expected that file-id would be a filename unique for the document such as `[Attachment: vat-rates.csv]`.

These are intended to be introduced to users in Content Publisher. I've marked them both as experimental as it's still early in the development of attachments for Content Publisher and there is work that may well change how they behave.