### PR TITLE
 Use govuk_publishing_components to render attachment links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Add dependency on govuk_publishing_components
 * Add new `AttachementLink:attachment-id` extension and mark as experimental
 * Add new `Attachement:attachment-id` extension and mark as experimental
 * Blockquote quote remover is now more forgiving to spaces before or after quote characters

--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -32,6 +32,7 @@ library for use in the UK Government Single Domain project'
 
   s.add_dependency 'actionview', '~> 5.0'
   s.add_dependency 'addressable', '>= 2.3.8', '< 3'
+  s.add_dependency 'govuk_publishing_components', '>= 16.14'
   s.add_dependency 'htmlentities', '~> 4'
   s.add_dependency 'i18n', '~> 0.7'
   s.add_dependency 'kramdown', '~> 1.15.0'

--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -60,7 +60,7 @@ class Govspeak::HtmlSanitizer
   def sanitize_config
     Sanitize::Config.merge(
       Sanitize::Config::RELAXED,
-      elements: Sanitize::Config::RELAXED[:elements] + %w[govspeak-embed-attachment],
+      elements: Sanitize::Config::RELAXED[:elements] + %w[govspeak-embed-attachment govspeak-embed-attachment-link],
       attributes: {
         :all => Sanitize::Config::RELAXED[:attributes][:all] + ["role", "aria-label"],
         "a"  => Sanitize::Config::RELAXED[:attributes]["a"] + button_sanitize_config,

--- a/lib/govspeak/post_processor.rb
+++ b/lib/govspeak/post_processor.rb
@@ -70,6 +70,24 @@ module Govspeak
       end
     end
 
+    extension("embed attachment link HTML") do |document|
+      document.css("govspeak-embed-attachment-link").map do |el|
+        attachment = govspeak_document.attachments.detect { |a| a[:id] == el["id"] }
+
+        unless attachment
+          el.remove
+          next
+        end
+
+        attachment_html = GovukPublishingComponents.render(
+          "govuk_publishing_components/components/attachment_link",
+          attachment: attachment,
+          locale: govspeak_document.locale
+        )
+        el.swap(attachment_html)
+      end
+    end
+
     attr_reader :input, :govspeak_document
 
     def initialize(html, govspeak_document)

--- a/test/govspeak_attachment_link_test.rb
+++ b/test/govspeak_attachment_link_test.rb
@@ -1,0 +1,29 @@
+# encoding: UTF-8
+
+require "test_helper"
+
+class GovspeakAttachmentLinkTest < Minitest::Test
+  def render_govspeak(govspeak, attachments = [])
+    Govspeak::Document.new(govspeak, attachments: attachments).to_html
+  end
+
+  test "renders an empty string for attachment link that is not found" do
+    assert_equal("\n", render_govspeak("[AttachmentLink:file.pdf]", []))
+  end
+
+  test "renders an attachment link component for a found attachment link" do
+    attachment = {
+      id: "attachment.pdf",
+      url: "http://example.com/attachment.pdf",
+      title: "Attachment Title",
+    }
+
+    html = GovukPublishingComponents.render(
+      "govuk_publishing_components/components/attachment_link",
+      attachment: attachment
+    )
+    rendered = render_govspeak("[AttachmentLink:attachment.pdf]", [attachment])
+    assert_equal(html + "\n", rendered)
+    assert_match(%r{href="http://example.com/attachment.pdf"}, rendered)
+  end
+end

--- a/test/govspeak_attachments_inline_test.rb
+++ b/test/govspeak_attachments_inline_test.rb
@@ -169,12 +169,4 @@ class GovspeakAttachmentsInlineTest < Minitest::Test
     rendered = render_govspeak("[embed:attachments:inline: path/to/file name.jpg ]")
     assert_equal("\n", rendered)
   end
-
-  test "supports alternative syntax for attachment links" do
-    rendered = render_govspeak(
-      "[AttachmentLink:f.pdf]",
-      [build_attachment(content_id: nil, id: "f.pdf", url: "http://a.b/f.pdf", title: "My Pdf")]
-    )
-    assert_match(%r{<a href="http://a.b/f.pdf">My Pdf</a>}, rendered)
-  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/zMYmFTPx/801-show-metadata-for-attachments

This is a draft PR until govuk_publishing_components is released and we can set that gem appropriately.

This sets the rendering of an AttachmentLink to be done via
govuk_publishing_components rather than done by govspeak logic.

It is moved to the post processing section so that there is no need to
be worried about new line characters breaking any markdown.