### PR TITLE
Release v6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 6.1.0
 
 * Remove `[embed:attachments:content-id]` this isn't used by any apps and has never worked
 * Add dependency on govuk_publishing_components

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "6.0.0".freeze
+  VERSION = "6.1.0".freeze
 end


### PR DESCRIPTION
## 6.1.0

* Remove `[embed:attachments:content-id]` this isn't used by any apps and has never worked
* Add dependency on govuk_publishing_components
* Add new `AttachementLink:attachment-id` extension and mark as experimental
* Add new `Attachement:attachment-id` extension and mark as experimental
* Blockquote quote remover is now more forgiving to spaces before or after quote characters
