### PR TITLE
Update warning callout label text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Update warning callout label text from 'Help' to 'Warning'
+
 # 6.2.0
 
 * Remove experimental status on `AttachementLink:attachment-id` and `Attachement:attachment-id`

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ creates a callout with an info (i) icon.
 creates a callout with a warning or alert (!) icon
 
 ```html
-<div role="note" aria-label="Help" class="application-notice help-notice">
+<div role="note" aria-label="Warning" class="application-notice help-notice">
   <p>This is a warning callout</p>
 </div>
 ```

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -191,7 +191,7 @@ module Govspeak
     }
 
     extension('helpful', surrounded_by("%")) { |body|
-      %{\n\n<div role="note" aria-label="Help" class="application-notice help-notice">\n#{Govspeak::Document.new(body.strip).to_html}</div>\n}
+      %{\n\n<div role="note" aria-label="Warning" class="application-notice help-notice">\n#{Govspeak::Document.new(body.strip).to_html}</div>\n}
     }
 
     extension('barchart', /{barchart(.*?)}/) do |captures|

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -194,7 +194,7 @@ Teston
 
   test_given_govspeak "% I am very helpful %" do
     assert_html_output %{
-      <div role="note" aria-label="Help" class="application-notice help-notice">
+      <div role="note" aria-label="Warning" class="application-notice help-notice">
       <p>I am very helpful</p>
       </div>}
     assert_text_output "I am very helpful"
@@ -204,7 +204,7 @@ Teston
     assert_html_output %{
       <p>The following is very helpful</p>
 
-      <div role="note" aria-label="Help" class="application-notice help-notice">
+      <div role="note" aria-label="Warning" class="application-notice help-notice">
       <p>I am very helpful</p>
       </div>}
     assert_text_output "The following is very helpful I am very helpful"
@@ -214,7 +214,7 @@ Teston
     assert_html_output %{
       <h2 id="hello">Hello</h2>
 
-      <div role="note" aria-label="Help" class="application-notice help-notice">
+      <div role="note" aria-label="Warning" class="application-notice help-notice">
       <p>I am very helpful</p>
       </div>
 
@@ -224,7 +224,7 @@ Teston
 
   test_given_govspeak "% I am very helpful" do
     assert_html_output %{
-      <div role="note" aria-label="Help" class="application-notice help-notice">
+      <div role="note" aria-label="Warning" class="application-notice help-notice">
       <p>I am very helpful</p>
       </div>}
     assert_text_output "I am very helpful"


### PR DESCRIPTION
Change label from 'Help' to 'Warning'

The bold callout with the exclamation icon has an invisible label saying "Help". This is generally not appropriate and misleading for screenreader users.

The callout is called "warning callout" and is probably mostly used for warnings.

Note: the extension name is currently named `helpful`. Note sure if we should change that or not