### PR TITLE
Fix attachment link paragraphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Fix wrapping `AttachmentLink:attachment-id` in a paragraph when used inline
+
 ## 6.1.0
 
 * Remove `[embed:attachments:content-id]` this isn't used by any apps and has never worked

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -3,7 +3,7 @@ require 'active_support/core_ext/array'
 require 'erb'
 require 'htmlentities'
 require 'kramdown'
-require 'kramdown/parser/kramdown_with_automatic_external_links'
+require 'kramdown/parser/govuk'
 require 'rinku'
 require 'govuk_publishing_components'
 require 'govspeak/header_extractor'
@@ -21,14 +21,13 @@ require 'govspeak/presenters/h_card_presenter'
 require 'govspeak/presenters/image_presenter'
 require 'govspeak/presenters/attachment_image_presenter'
 
-
 module Govspeak
   def self.root
     File.expand_path('..', File.dirname(__FILE__))
   end
 
   class Document
-    Parser = Kramdown::Parser::KramdownWithAutomaticExternalLinks
+    Parser = Kramdown::Parser::Govuk
     PARSER_CLASS_NAME = Parser.name.split("::").last
     UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.freeze
     NEW_PARAGRAPH_LOOKBEHIND = %q{(?<=\A|\n\n|\r\n\r\n)}.freeze

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -353,6 +353,8 @@ module Govspeak
     # Content Publisher and should be considered experimental as it is likely
     # to be iterated in the short term.
     extension('Attachment', /#{NEW_PARAGRAPH_LOOKBEHIND}\[Attachment:\s*(.*?)\s*\]/) do |attachment_id|
+      next "" if attachments.none? { |a| a[:id] == attachment_id }
+
       %{<govspeak-embed-attachment id="#{attachment_id}"></govspeak-embed-attachment>}
     end
 
@@ -360,6 +362,8 @@ module Govspeak
     # syntax is being used by Content Publisher and should be considered
     # experimental
     extension('AttachmentLink', /\[AttachmentLink:\s*(.*?)\s*\]/) do |attachment_id|
+      next "" if attachments.none? { |a| a[:id] == attachment_id }
+
       %{<govspeak-embed-attachment-link id="#{attachment_id}"></govspeak-embed-attachment-link>}
     end
 

--- a/lib/kramdown/parser/govuk.rb
+++ b/lib/kramdown/parser/govuk.rb
@@ -21,6 +21,8 @@ module Kramdown
 
   module Parser
     class Govuk < Kramdown::Parser::Kramdown
+      CUSTOM_INLINE_ELEMENTS = %w(govspeak-embed-attachment-link).freeze
+
       def initialize(source, options)
         @document_domains = options[:document_domains] || %w(www.gov.uk)
         super
@@ -39,6 +41,12 @@ module Kramdown
           end
           # rubocop:enable Lint/HandleExceptions
         end
+        super
+      end
+
+      def parse_block_html
+        return false if CUSTOM_INLINE_ELEMENTS.include?(@src[1].downcase)
+
         super
       end
     end

--- a/lib/kramdown/parser/govuk.rb
+++ b/lib/kramdown/parser/govuk.rb
@@ -20,7 +20,7 @@ module Kramdown
   end
 
   module Parser
-    class KramdownWithAutomaticExternalLinks < Kramdown::Parser::Kramdown
+    class Govuk < Kramdown::Parser::Kramdown
       def initialize(source, options)
         @document_domains = options[:document_domains] || %w(www.gov.uk)
         super

--- a/test/govspeak_attachment_link_test.rb
+++ b/test/govspeak_attachment_link_test.rb
@@ -22,4 +22,19 @@ class GovspeakAttachmentLinkTest < Minitest::Test
     assert_match(/<span class="gem-c-attachment-link">/, rendered)
     assert_match(%r{href="http://example.com/attachment.pdf"}, rendered)
   end
+
+  test "renders an attachment link inside a paragraph" do
+    attachment = {
+      id: "attachment.pdf",
+      url: "http://example.com/attachment.pdf",
+      title: "Attachment Title",
+    }
+
+    rendered = render_govspeak("[AttachmentLink:attachment.pdf] test", [attachment])
+    root = Nokogiri::HTML.fragment(rendered).css(":root").first
+
+    assert(root.name, "p")
+    assert(root.css("p").size, 0)
+    assert_match(/Attachment Title\s*test/, root.text)
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/zMYmFTPx/801-show-attachments-in-govspeak

This treats the custom element `<govspeak-embed-attachment-link />` as an inline element and thus is automatically wrapped in paragraph elements when used in govspeak.