### PR TITLE
Remove experimental status of Attachment extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Remove experimental status on `AttachementLink:attachment-id` and `Attachement:attachment-id`
+* Deprecate `embed:attachments:inline:content-id`
+
 ## 6.1.1
 
 * Fix wrapping `AttachmentLink:attachment-id` in a paragraph when used inline

--- a/README.md
+++ b/README.md
@@ -352,7 +352,83 @@ Embedded content allows authors to reference a supporting item of a document by
 referencing an id. The details of this content is passed to the publishing
 application to govspeak at the time of rendering.
 
-### Inline Attachment
+### Attachments
+
+Attachments can be be rendered as blocks
+
+    [Attachment:file.txt]
+
+with options provided
+
+    {
+      attachments: [
+        {
+          id: "file.txt",
+          title: "My attached file",
+          url: "http://example.com/file.txt",
+          filename: "file.txt",
+          content_type: "text/plain",
+          file_size: 1024,
+        }
+      ]
+    }
+
+will output an attachment block
+
+```html
+<section class="gem-c-attachment">
+  <div class="gem-c-attachment__thumbnail">
+    <a class="govuk-link" target="_self" tabindex="-1" aria-hidden="true" href="http://example.com/file.txt">
+        <svg class="gem-c-attachment__thumbnail-image" version="1.1" viewbox="0 0 84 120" width="84" height="120" aria-hidden="true">
+  <path d="M74.85 5v106H5" fill="none" stroke-miterlimit="10" stroke-width="2"></path>
+  <path d="M79.85 10v106H10" fill="none" stroke-miterlimit="10" stroke-width="2"></path>
+</svg>
+
+</a>
+</div>
+  <div class="gem-c-attachment__details">
+    <h2 class="gem-c-attachment__title">
+      <a class="govuk-link" target="_self" href="http://example.com/file.txt">My attached file</a>
+</h2>
+      <p class="gem-c-attachment__metadata"><span class="gem-c-attachment__attribute">Plain Text</span>, <span class="gem-c-attachment__attribute">1 KB</span></p>
+
+
+</div></section>
+```
+
+### Attachment Links
+
+Attachments can be be rendered inline as links
+
+    Some information about [AttachmentLink:file.pdf]
+
+with options provided
+
+    {
+      attachments: [
+        {
+          id: "file.pdf",
+          title: "My PDF",
+          url: "http://example.com/file.pdf",
+          filename: "file.pdf",
+          content_type: "application/pdf",
+          file_size: 32768,
+          number_of_pages: 2,
+        }
+      ]
+    }
+
+will output an attachment link within a paragraph of text
+
+```html
+<p>Some information about <span class="gem-c-attachment-link">
+  <a class="govuk-link" href="http://example.com/file.pdf">My PDF</a>
+
+  (<span class="gem-c-attachment-link__attribute"><abbr title="Portable Document Format" class="gem-c-attachment-link__abbr">PDF</abbr></span>, <span class="gem-c-attachment-link__attribute">32 KB</span>, <span class="gem-c-attachment-link__attribute">2 pages</span>)
+</span></p>
+```
+
+### Inline Attachments (DEPRECATED: use `AttachmentLink:attachment-id` instead)
 
 Attachments can be linked to inline
 

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -217,6 +217,7 @@ module Govspeak
       render_image(ImagePresenter.new(image))
     end
 
+    # DEPRECATED: use 'AttachmentLink:attachment-id' instead
     extension('embed attachment inline', /\[embed:attachments:inline:\s*(.*?)\s*\]/) do |content_id|
       attachment = attachments.detect { |a| a[:content_id] == content_id }
       next "" unless attachment
@@ -348,19 +349,12 @@ module Govspeak
       render_image(ImagePresenter.new(image))
     end
 
-    # This is an alternative syntax for embedding attachments using a readable id (expected
-    # to be a unique variation of a filename). This syntax is being used by
-    # Content Publisher and should be considered experimental as it is likely
-    # to be iterated in the short term.
     extension('Attachment', /#{NEW_PARAGRAPH_LOOKBEHIND}\[Attachment:\s*(.*?)\s*\]/) do |attachment_id|
       next "" if attachments.none? { |a| a[:id] == attachment_id }
 
       %{<govspeak-embed-attachment id="#{attachment_id}"></govspeak-embed-attachment>}
     end
 
-    # This is an alternative syntax for embedding attachments as links. This
-    # syntax is being used by Content Publisher and should be considered
-    # experimental
     extension('AttachmentLink', /\[AttachmentLink:\s*(.*?)\s*\]/) do |attachment_id|
       next "" if attachments.none? { |a| a[:id] == attachment_id }
 


### PR DESCRIPTION
Trello: https://trello.com/c/BQ5bBkMw/881-wrap-up-technical-loose-ends-on-attachments

These are now in production use by Content Publisher so their
experimental status has been removed.

As part of this the `[embed:attachments:inline:content-id]` extension
has been deprecated as this provides the same functionality as
`[AttachmentLink:attachment-id]`. At the time of writing this extension
is not directly used by any government publishers and is only used
behind the scenes in Specialist Publisher - A user enters a numeric
syntax and at the point of sending to Publishing API the govspeak is
converted to the inline syntax.