### PR TITLE
Add extension to allow table headers with scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 6.3.0
+## Unreleased
+
+ * Add table heading syntax that allows a table cell outside of `thead` to be marked as a table heading with a scope of row.
+
+ ## 6.3.0
 
 * Unicode characters forbidden in HTML are stripped from input
 * Validation is now more lenient for HTML input

--- a/lib/govspeak/post_processor.rb
+++ b/lib/govspeak/post_processor.rb
@@ -86,15 +86,16 @@ module Govspeak
     extension("Add table headers and row / column scopes") do |document|
       document.css("thead th").map do |el|
         el.content = el.content.gsub(/^# /, '')
-        el.content = el.content.gsub(/[[:space:]]/, '') if el.content.blank? # Removes a strange whitespace in the cell if the cell is already blank
-        el[:scope] = "col" if el.content.present?
+        el.content = el.content.gsub(/[[:space:]]/, '') if el.content.blank? # Removes a strange whitespace in the cell if the cell is already blank.
+        el.name = 'td' if el.content.blank? # This prevents a `th` with nothing inside it; a `td` is preferable.
+        el[:scope] = "col" if el.content.present? # `scope` shouldn't be used if there's nothing in the table heading.
       end
 
-      document.css(":not(thead) td").map do |el|
-        if el.content.match?(/^#.*$/)
-          el.name = 'th'
-          el[:scope] = 'row'
-          el.content = el.content.gsub(/^# /, '')
+      document.css(":not(thead) tr td:first-child").map do |el|
+        if el.content.match?(/^#($|\s.*$)/)
+          el.content = el.content.gsub(/^#($|\s)/, '') # Replace '# ' and '#', but not '#Word'.
+          el.name = 'th' if el.content.present? # This also prevents a `th` with nothing inside it; a `td` is preferable.
+          el[:scope] = 'row' if el.content.present? # `scope` shouldn't be used if there's nothing in the table heading.
         end
       end
     end

--- a/lib/govspeak/post_processor.rb
+++ b/lib/govspeak/post_processor.rb
@@ -83,6 +83,22 @@ module Govspeak
       end
     end
 
+    extension("Add table headers and row / column scopes") do |document|
+      document.css("thead th").map do |el|
+        el.content = el.content.gsub(/^# /, '')
+        el.content = el.content.gsub(/[[:space:]]/, '') if el.content.blank? # Removes a strange whitespace in the cell if the cell is already blank
+        el[:scope] = "col" if el.content.present?
+      end
+
+      document.css(":not(thead) td").map do |el|
+        if el.content.match?(/^#.*$/)
+          el.name = 'th'
+          el[:scope] = 'row'
+          el.content = el.content.gsub(/^# /, '')
+        end
+      end
+    end
+
     attr_reader :input, :govspeak_document
 
     def initialize(html, govspeak_document)

--- a/test/govspeak_table_with_headers_test.rb
+++ b/test/govspeak_table_with_headers_test.rb
@@ -1,0 +1,122 @@
+require 'test_helper'
+
+class GovspeakTableWithHeadersTest < Minitest::Test
+  def expected_outcome
+%{
+<table>
+  <thead>
+    <tr>
+      <th></th>
+      <th scope="col">Second Column</th>
+      <th scope="col">Third Column</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">First row</th>
+      <td>Cell</td>
+      <td>Cell</td>
+    </tr>
+    <tr>
+      <th scope="row">Second row</th>
+      <td>Cell</td>
+      <td>Cell</td>
+    </tr>
+  </tbody>
+</table>
+}
+  end
+
+  def expected_outcome_with_hashes_in_cell_contents
+%{
+<table>
+  <thead>
+    <tr>
+      <th></th>
+      <th scope="col">Second Column</th>
+      <th scope="col">Third Column</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">First row</th>
+      <td># Cell</td>
+      <td># Cell</td>
+    </tr>
+    <tr>
+      <th scope="row">Second row</th>
+      <td>Cell</td>
+      <td>Cell</td>
+    </tr>
+  </tbody>
+</table>
+}
+  end
+
+  def expected_outcome_for_table_with_alignments
+    %{
+<table>
+  <thead>
+    <tr>
+      <th style="text-align: left"></th>
+      <th style="text-align: center" scope="col">Second Column</th>
+      <th style="text-align: right" scope="col">Third Column</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th style="text-align: left" scope="row">First row</th>
+      <td style="text-align: center">Cell</td>
+      <td style="text-align: right">Cell</td>
+    </tr>
+    <tr>
+      <th style="text-align: left" scope="row">Second row</th>
+      <td style="text-align: center">Cell</td>
+      <td style="text-align: right">Cell</td>
+    </tr>
+  </tbody>
+</table>
+}
+
+  end
+
+  def document_body_with_hashes_for_all_headers
+    @document_body_with_hashes_for_all_headers ||= Govspeak::Document.new(%{
+|                 |# Second Column  |# Third Column       |
+| --------------- | --------------- | ------------------- |
+|# First row      | Cell            | Cell                |
+|# Second row     | Cell            | Cell                |
+})
+end
+
+  def document_body_with_hashes_for_row_headers
+    @document_body_with_hashes_for_row_headers ||= Govspeak::Document.new(%{
+|                 | Second Column   | Third Column        |
+| --------------- | --------------- | ------------------- |
+|# First row      | Cell            | Cell                |
+|# Second row     | Cell            | Cell                |
+})
+  end
+
+  def document_body_with_alignments
+    @document_body_with_alignments ||= Govspeak::Document.new(%{
+|                 | Second Column   | Third Column        |
+| :-------------- | :-------------: | ------------------: |
+|# First row      | Cell            | Cell                |
+|# Second row     | Cell            | Cell                |
+})
+  end
+
+  test "Cells with |# are headers" do
+    assert_equal document_body_with_hashes_for_all_headers.to_html, expected_outcome
+  end
+
+
+  test "Cells outside of thead with |# are th; thead still only contains th" do
+    assert_equal document_body_with_hashes_for_row_headers.to_html, expected_outcome
+  end
+
+  test "Cells are aligned correctly" do
+    assert_equal document_body_with_alignments.to_html, expected_outcome_for_table_with_alignments
+  end
+end

--- a/test/govspeak_table_with_headers_test.rb
+++ b/test/govspeak_table_with_headers_test.rb
@@ -6,7 +6,7 @@ class GovspeakTableWithHeadersTest < Minitest::Test
 <table>
   <thead>
     <tr>
-      <th></th>
+      <td></td>
       <th scope="col">Second Column</th>
       <th scope="col">Third Column</th>
     </tr>
@@ -32,7 +32,7 @@ class GovspeakTableWithHeadersTest < Minitest::Test
 <table>
   <thead>
     <tr>
-      <th></th>
+      <td></td>
       <th scope="col">Second Column</th>
       <th scope="col">Third Column</th>
     </tr>
@@ -58,7 +58,7 @@ class GovspeakTableWithHeadersTest < Minitest::Test
 <table>
   <thead>
     <tr>
-      <th style="text-align: left"></th>
+      <td style="text-align: left"></td>
       <th style="text-align: center" scope="col">Second Column</th>
       <th style="text-align: right" scope="col">Third Column</th>
     </tr>
@@ -73,6 +73,58 @@ class GovspeakTableWithHeadersTest < Minitest::Test
       <th style="text-align: left" scope="row">Second row</th>
       <td style="text-align: center">Cell</td>
       <td style="text-align: right">Cell</td>
+    </tr>
+  </tbody>
+</table>
+}
+  end
+
+  def expected_outcome_for_table_headers_in_the_wrong_place
+    %{
+<table>
+  <thead>
+    <tr>
+      <td></td>
+      <th scope="col">Second Column</th>
+      <th scope="col">Third Column</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">First row</th>
+      <td># Cell</td>
+      <td>Cell</td>
+    </tr>
+    <tr>
+      <th scope="row">Second row</th>
+      <td>Cell</td>
+      <td># Cell</td>
+    </tr>
+  </tbody>
+</table>
+}
+  end
+
+  def expected_outcome_for_table_with_blank_table_headers
+    %{
+<table>
+  <thead>
+    <tr>
+      <td></td>
+      <th scope="col">Second Column</th>
+      <th scope="col">Third Column</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td></td>
+      <td>Cell</td>
+      <td>Cell</td>
+    </tr>
+    <tr>
+      <th scope="row">Second row</th>
+      <td>Cell</td>
+      <td>Cell</td>
     </tr>
   </tbody>
 </table>
@@ -106,10 +158,27 @@ class GovspeakTableWithHeadersTest < Minitest::Test
 })
   end
 
+  def document_body_with_table_headers_in_the_wrong_place
+    @document_body_with_table_headers_in_the_wrong_place ||= Govspeak::Document.new(%{
+|                 | Second Column   | Third Column        |
+| --------------- | --------------- | ------------------- |
+|# First row      |# Cell           | Cell                |
+|# Second row     | Cell            |# Cell               |
+})
+  end
+
+  def document_body_with_blank_table_headers
+    @document_body_with_blank_table_headers ||= Govspeak::Document.new(%{
+|                 | Second Column   | Third Column        |
+| --------------- | --------------- | ------------------- |
+|#                | Cell            | Cell                |
+|# Second row     | Cell            | Cell                |
+})
+  end
+
   test "Cells with |# are headers" do
     assert_equal document_body_with_hashes_for_all_headers.to_html, expected_outcome
   end
-
 
   test "Cells outside of thead with |# are th; thead still only contains th" do
     assert_equal document_body_with_hashes_for_row_headers.to_html, expected_outcome
@@ -117,5 +186,13 @@ class GovspeakTableWithHeadersTest < Minitest::Test
 
   test "Cells are aligned correctly" do
     assert_equal document_body_with_alignments.to_html, expected_outcome_for_table_with_alignments
+  end
+
+  test "Table headers with a scope of row are only in the first column of the table" do
+    assert_equal document_body_with_table_headers_in_the_wrong_place.to_html, expected_outcome_for_table_headers_in_the_wrong_place
+  end
+
+  test "Table headers are not blank" do
+    assert_equal document_body_with_blank_table_headers.to_html, expected_outcome_for_table_with_blank_table_headers
   end
 end

--- a/test/govspeak_table_with_headers_test.rb
+++ b/test/govspeak_table_with_headers_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class GovspeakTableWithHeadersTest < Minitest::Test
   def expected_outcome
-%{
+    %{
 <table>
   <thead>
     <tr>
@@ -28,7 +28,7 @@ class GovspeakTableWithHeadersTest < Minitest::Test
   end
 
   def expected_outcome_with_hashes_in_cell_contents
-%{
+    %{
 <table>
   <thead>
     <tr>
@@ -77,7 +77,6 @@ class GovspeakTableWithHeadersTest < Minitest::Test
   </tbody>
 </table>
 }
-
   end
 
   def document_body_with_hashes_for_all_headers
@@ -87,7 +86,7 @@ class GovspeakTableWithHeadersTest < Minitest::Test
 |# First row      | Cell            | Cell                |
 |# Second row     | Cell            | Cell                |
 })
-end
+  end
 
   def document_body_with_hashes_for_row_headers
     @document_body_with_hashes_for_row_headers ||= Govspeak::Document.new(%{

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -119,7 +119,7 @@ Teston
       {barchart}
     GOVSPEAK
     html = Govspeak::Document.new(input).to_html
-    assert_equal %{<table class=\"js-barchart-table mc-auto-outdent\">\n  <thead>\n    <tr>\n      <th>col</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td>val</td>\n    </tr>\n  </tbody>\n</table>\n}, html
+    assert_equal %{<table class=\"js-barchart-table mc-auto-outdent\">\n  <thead>\n    <tr>\n      <th scope="col">col</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td>val</td>\n    </tr>\n  </tbody>\n</table>\n}, html
   end
 
   test "should convert barchart with stacked compact and negative" do
@@ -130,7 +130,7 @@ Teston
       {barchart stacked compact negative}
     GOVSPEAK
     html = Govspeak::Document.new(input).to_html
-    assert_equal %{<table class=\"js-barchart-table mc-stacked compact mc-negative mc-auto-outdent\">\n  <thead>\n    <tr>\n      <th>col</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td>val</td>\n    </tr>\n  </tbody>\n</table>\n}, html
+    assert_equal %{<table class=\"js-barchart-table mc-stacked compact mc-negative mc-auto-outdent\">\n  <thead>\n    <tr>\n      <th scope="col">col</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td>val</td>\n    </tr>\n  </tbody>\n</table>\n}, html
   end
 
   test "address div is separated from paragraph text by a couple of line-breaks" do


### PR DESCRIPTION
Tables need table headings to be accessible - screen readers and other assistive technologies use them to help explain the relationship between a heading and a cell's contents.

This pull request adds the ability set a cell to be a table heading (`th`), even when it's not inside the `thead` element.

In Govspeak the following markdown will have three `th` elements inside the top row because the `|---|` means that the top row should sit inside a `thead`:

```
|                | Second Column  | Third Column      |
| -------------- | -------------- | ----------------- |
| First row      | Cell           | Cell              |
```
will become: 

|                | Second Column  | Third Column      |
| -------------- | -------------- | ----------------- |
| First row      | Cell           | Cell              |

But there is currently no way to set the cell containing the text 'First row' to be a `th` element.

This pull request adds a tweak to the table syntax - by adding a `#` after the pipe we can set the cell to be a `th`. This is optional inside the table head, so the following two examples have the same outcome:

```
|                | Second Column  | Third Column      |
| -------------- | -------------- | ----------------- |
|# First row     | Cell           | Cell              |
```

```
|                |# Second Column |# Third Column     |
| -------------- | -------------- | ----------------- |
|# First row     | Cell           | Cell              |
```

Output:

```html
<table>
  <thead>
    <tr>
      <td></td>
      <th scope="col">Second Column</th>
      <th scope="col">Third Column</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <th scope="row">First row</th>
      <td>Cell</td>
      <td>Cell</td>
    </tr>
  </tbody>
</table>
```

Fixes #110.

Ticket: https://trello.com/c/bRdKanmi/2-5-unsemantic-tables-23