### PR TITLE
Sets govuk-lint version to 3.11.5 and fixes minor linting errors

### DIFF
--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -40,7 +40,7 @@ library for use in the UK Government Single Domain project'
   s.add_dependency 'rinku', '~> 2.0'
   s.add_dependency "sanitize", "~> 5"
 
-  s.add_development_dependency 'govuk-lint'
+  s.add_development_dependency 'govuk-lint', '~> 3.11.5'
   s.add_development_dependency 'minitest', '~> 5.8.3'
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rake', '~> 0.9.0'

--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -50,11 +50,7 @@ class Govspeak::HtmlSanitizer
   end
 
   def button_sanitize_config
-    [
-      "data-module",
-      "data-tracking-code",
-      "data-tracking-name"
-    ]
+    %w[data-module data-tracking-code data-tracking-name]
   end
 
   def sanitize_config
@@ -62,7 +58,7 @@ class Govspeak::HtmlSanitizer
       Sanitize::Config::RELAXED,
       elements: Sanitize::Config::RELAXED[:elements] + %w[govspeak-embed-attachment govspeak-embed-attachment-link],
       attributes: {
-        :all => Sanitize::Config::RELAXED[:attributes][:all] + ["role", "aria-label"],
+        :all => Sanitize::Config::RELAXED[:attributes][:all] + %w[role aria-label],
         "a"  => Sanitize::Config::RELAXED[:attributes]["a"] + button_sanitize_config,
         "th"  => Sanitize::Config::RELAXED[:attributes]["th"] + %w[style],
         "td"  => Sanitize::Config::RELAXED[:attributes]["td"] + %w[style],


### PR DESCRIPTION
 - govuk-lint 3.11.4 turned on Ruby-on-Rails linting by default, which is problematic for apps that are Ruby but not Rails. Version 3.11.5 fixed this and has been set as the version that Govspeak should use.
 - Fixed small linting error in HTML Sanitizer - array of strings now use `%w`.