### PR TITLE
Sets govuk-lint version to 3.11.5

### DIFF
--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -40,7 +40,7 @@ library for use in the UK Government Single Domain project'
   s.add_dependency 'rinku', '~> 2.0'
   s.add_dependency "sanitize", "~> 5"
 
-  s.add_development_dependency 'govuk-lint'
+  s.add_development_dependency 'govuk-lint', '~> 3.11.5'
   s.add_development_dependency 'minitest', '~> 5.8.3'
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rake', '~> 0.9.0'


### PR DESCRIPTION
 - govuk-lint version 3.11.5 now doesn't have Rails linting turned on by default, so is a sensible version to set for this non-Rails Ruby app using the beautifully named twiddle-wakka / pessimistic operator.