### PR TITLE
Remove forbidden unicode characters from output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Update warning callout label text from 'Help' to 'Warning'
 
-# 6.2.0
+## 6.2.0
 
 * Remove experimental status on `AttachementLink:attachment-id` and `Attachement:attachment-id`
 * Deprecate `embed:attachments:inline:content-id`
@@ -54,25 +54,32 @@
 * Update sanitize version to 4.6.x [#127](https://github.com/alphagov/govspeak/issues/127)
 
 ## 5.5.0
+
 * Ignore links with blank or missing `href`s when extracting links from a document with `Govspeak::Document#extracted_links` [#124](https://github.com/alphagov/govspeak/pull/124)
 
 ## 5.4.0
+
 * Add an optional `website_root` argument to `Govspeak::Document#extracted_links` in order to get all links as fully qualified URLs [#122](https://github.com/alphagov/govspeak/pull/122)
 
 ## 5.3.0
+
 * Add a link extraction class for finding links in documents [#120](https://github.com/alphagov/govspeak/pull/120)
 
 ## 5.2.2
+
 * Fix rendering buttons with inconsistent linebreaks seen in publishing [#118](https://github.com/alphagov/govspeak/pull/118)
 
 ## 5.2.1
+
 * Fix validation to make sure buttons are considered valid
 * Only allow buttons to be used on new lines, not when indented or inline within text (useful for guides) [#116](https://github.com/alphagov/govspeak/pull/116)
 
 ## 5.2.0
+
 * Add button component for govspeak [#114](https://github.com/alphagov/govspeak/pull/114) see README for usage
 
 ## 5.1.0
+
 * Update Kramdown version to 1.15.0
 
 ## 5.0.3
@@ -80,14 +87,17 @@
 * Fix matching links/attachments/contacts by regex to use equality [#105](https://github.com/alphagov/govspeak/pull/105)
 
 ## 5.0.2
+
 * Loosen ActionView dependency to allow use with Rails
 5 [#99](https://github.com/alphagov/govspeak/pull/99)
 
 ## 5.0.1
+
 * Move presenters into the Govspeak namespace [#93](https://github.com/alphagov/govspeak/pull/93)
 * Embedded links now will automatically be marked with `rel="external"` [#96](https://github.com/alphagov/govspeak/pull/96)
 
 ## 5.0.0
+
 * Update Kramdown version to 1.12.0
 * Add pry-byebug to development dependencies
 * Ability to run Govspeak as a binary from command line [#87](https://github.com/alphagov/govspeak/pull/87)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Unicode characters forbidden in HTML are stripped from input
+* Validation is now more lenient for HTML input
+
 ## 6.2.1
 
 * Update warning callout label text from 'Help' to 'Warning'

--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -1,5 +1,4 @@
 require 'addressable/uri'
-require 'sanitize'
 
 class Govspeak::HtmlSanitizer
   class ImageSourceWhitelister

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -18,6 +18,13 @@ class GovspeakTest < Minitest::Test
     assert_equal "<p><em>this is markdown</em></p>\n", rendered
   end
 
+  test "strips forbidden unicode characters" do
+    rendered = Govspeak::Document.new(
+      "this is text with forbidden characters \ufffc\u2028\ufeff\u202c\u202a"
+    ).to_html
+    assert_equal "<p>this is text with forbidden characters</p>\n", rendered
+  end
+
   test "highlight-answer block extension" do
     rendered = Govspeak::Document.new("this \n{::highlight-answer}Lead in to *BIG TEXT*\n{:/highlight-answer}").to_html
     assert_equal %{<p>this</p>\n\n<div class="highlight-answer">\n<p>Lead in to <em>BIG TEXT</em></p>\n</div>\n}, rendered


### PR DESCRIPTION
Trello: https://trello.com/c/LFamxCVY/954-investigating-relaxing-or-removing-sanitisation-from-govspeak-6-so-we-can-upgrade-whitehall

This is to resolve a blocking issue that prevents Whitehall from
upgrading to Govspeak > 5.5. A problem we have is that a number of pieces of
Whitehall content have unusual unicode characters that the Santize gem
strips out, this then makes the content fail HTML Validation and was
introduced as part of a Santize update in
https://github.com/alphagov/govspeak/pull/127.

The approach I've taken to resolve this is to remove forbidden unicode
characters from the source markdown that is converted to HTML. Since
these characters are invalid in a HTML output it seems reasonable to
consider them as invalid as part of govspeak input.

Looking through Whitehalls database I found there to be 765
Edition::Translation models and 248 GovspeakContent models that have at
last one of these characters in their body fields.

Initially I intended to resolve this with a data migration on Whitehall,
however that would have caused a problem if anyone used these characters
again as it would be very difficult to determine why content was failing
govspeak validation. I figure it's actually more user friendly to strip
the character out and then if they notice a space or similar is missing
they can correct that with their keyboard.

I noticed that in 2019 there had been 74 of these items added so this
doesn't appear to be a legacy issue. My current theory is that perhaps
these are characters that are present in content that is being pasted
from such as a PDF document.

Anyway, with this merged in Whitehall can proceed to be upgraded to
Govspeak 6 as with this and
https://github.com/alphagov/govspeak/pull/159 all GovspeakContent models
are valid govspeak and only 14 Edition::Translation bodies are invalid,
all of which are also invalid under Govspeak 5.5.