### PR TITLE
Bump to 6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 6.3.0
 
 * Unicode characters forbidden in HTML are stripped from input
 * Validation is now more lenient for HTML input

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "6.2.1".freeze
+  VERSION = "6.3.0".freeze
 end


### PR DESCRIPTION
* Unicode characters forbidden in HTML are stripped from input: https://github.com/alphagov/govspeak/pull/164
* Validation is now more lenient for HTML input: https://github.com/alphagov/govspeak/pull/159