### PR TITLE
Allow link data attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Allow data attributes on links
+
 ## 6.4.0
 
  * Add table heading syntax that allows a table cell outside of `thead` to be marked as a table heading with a scope of row. (PR#161)

--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -48,21 +48,13 @@ class Govspeak::HtmlSanitizer
     Sanitize.clean(@dirty_html, Sanitize::Config.merge(sanitize_config, transformers: transformers))
   end
 
-  def button_sanitize_config
-    %w[
-      data-module
-      data-tracking-code
-      data-tracking-name
-    ]
-  end
-
   def sanitize_config
     Sanitize::Config.merge(
       Sanitize::Config::RELAXED,
       elements: Sanitize::Config::RELAXED[:elements] + %w[govspeak-embed-attachment govspeak-embed-attachment-link],
       attributes: {
         :all => Sanitize::Config::RELAXED[:attributes][:all] + %w[role aria-label],
-        "a"  => Sanitize::Config::RELAXED[:attributes]["a"] + button_sanitize_config,
+        "a"  => Sanitize::Config::RELAXED[:attributes]["a"] + [:data],
         "th"  => Sanitize::Config::RELAXED[:attributes]["th"] + %w[style],
         "td"  => Sanitize::Config::RELAXED[:attributes]["td"] + %w[style],
         "govspeak-embed-attachment" => %w[content-id],

--- a/test/html_sanitizer_test.rb
+++ b/test/html_sanitizer_test.rb
@@ -35,6 +35,15 @@ class HtmlSanitizerTest < Minitest::Test
     )
   end
 
+  test "allow data attributes on links" do
+    html = "<a href='/' data-module='track-click' data-ecommerce-path='/' data-track-category='linkClicked'>Test Link</a>"
+
+    assert_equal(
+      "<a href=\"/\" data-module=\"track-click\" data-ecommerce-path=\"/\" data-track-category=\"linkClicked\">Test Link</a>",
+      Govspeak::HtmlSanitizer.new(html).sanitize
+    )
+  end
+
   test "allows images on whitelisted domains" do
     html = "<img src='http://allowed.com/image.jgp'>"
     sanitized_html = Govspeak::HtmlSanitizer.new(html, allowed_image_hosts: ['allowed.com']).sanitize


### PR DESCRIPTION
## What
Allow any data attributes on links when sanitizing markdown

## Why
We have a use case for specifying content for a new landing page within a YML file. If this content contains a link which we want to track, at the moment this isn't possible as conversion of markdown to govspeak strips out the data attributes. In the case of ecommerce tracking, where we want to specify the linked-to page content id, it would be more difficult to add this logic into the presenter after the markdown has been converted.

**Note: I've gone with the approach of allowing any data attributes because tracking attributes can be varied and I'm not aware of any implications of allowing them all. Happy to switch to specific data attributes only if people prefer that approach**