### PR TITLE
Change the characters that we test for sanitisation

### DIFF
--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -41,7 +41,6 @@ library for use in the UK Government Single Domain project'
   s.add_dependency 'rinku', '~> 2.0'
   s.add_dependency "sanitize", "~> 5"
 
-  s.add_development_dependency 'govuk-lint', '~> 3.11.5'
   s.add_development_dependency 'minitest', '~> 5.8.3'
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rake', '~> 0.9.0'

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -20,7 +20,7 @@ class GovspeakTest < Minitest::Test
 
   test "strips forbidden unicode characters" do
     rendered = Govspeak::Document.new(
-      "this is text with forbidden characters \ufffc\u2028\ufeff\u202c\u202a"
+      "this is text with forbidden characters \u0008\u000b\ufffe\u{2ffff}\u{5fffe}"
     ).to_html
     assert_equal "<p>this is text with forbidden characters</p>\n", rendered
   end


### PR DESCRIPTION
The gem that we use to sanitize html has recently changed the list of characters that it checks for.
https://github.com/rgrove/sanitize/commit/0d4158fe3108709cfe93c40371cf01e07b8debf1

This changes the tests that we run to ensure that characters are being stripped to reflect these changes.

This change is being made prior to introduction of rubocop govuk. I've had to remove govuk-lint in order to get this to pass but will be raising a PR shortly that introduces rubocop-govuk.