### PR TITLE
Move to rubocop govuk

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+
 Metrics/BlockLength:
   Exclude:
     - '*.gemspec'
     - 'test/**/*'
-Style/TrivialAccessors:
-  IgnoreClassMethods: true

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ Bundler::GemHelper.install_tasks
 desc "Run basic tests"
 Rake::TestTask.new("test") { |t|
   t.libs << "test"
-  t.pattern = 'test/*_test.rb'
+  t.pattern = "test/*_test.rb"
   t.verbose = true
   t.warning = true
 }

--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -44,6 +44,7 @@ library for use in the UK Government Single Domain project'
   s.add_development_dependency 'minitest', '~> 5.8.3'
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rake', '~> 0.9.0'
+  s.add_development_dependency 'rubocop-govuk', '~> 1'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'simplecov-rcov'
 end

--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -1,8 +1,8 @@
 # -*- encoding: utf-8 -*-
 
-$:.push File.expand_path('lib', __dir__)
+$:.push File.expand_path("lib", __dir__)
 
-require 'govspeak/version'
+require "govspeak/version"
 
 Gem::Specification.new do |s|
   s.name          = "govspeak"
@@ -11,40 +11,40 @@ Gem::Specification.new do |s|
   s.authors       = ["GOV.UK Dev"]
   s.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
   s.homepage      = "http://github.com/alphagov/govspeak"
-  s.summary       = 'Markup language for single domain'
+  s.summary       = "Markup language for single domain"
   s.description   = 'A set of extensions to markdown layered on top of the kramdown
 library for use in the UK Government Single Domain project'
 
   s.files         = Dir[
-    'lib/**/*',
-    'assets/*',
-    'config/*',
-    'locales/*',
-    'README.md',
-    'CHANGELOG.md',
-    'Gemfile',
-    'Rakefile'
+    "lib/**/*",
+    "assets/*",
+    "config/*",
+    "locales/*",
+    "README.md",
+    "CHANGELOG.md",
+    "Gemfile",
+    "Rakefile"
   ]
-  s.test_files    = Dir['test/**/*']
+  s.test_files    = Dir["test/**/*"]
   s.bindir        = "bin"
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.require_paths = %w[lib]
 
-  s.add_dependency 'actionview', '~> 5.0'
-  s.add_dependency 'addressable', '>= 2.3.8', '< 3'
-  s.add_dependency 'govuk_publishing_components', '>= 16.16'
-  s.add_dependency 'htmlentities', '~> 4'
-  s.add_dependency 'i18n', '~> 0.7'
-  s.add_dependency 'kramdown', '~> 1.15.0'
-  s.add_dependency 'nokogiri', '~> 1.5'
-  s.add_dependency 'nokogumbo', '~> 2'
-  s.add_dependency 'rinku', '~> 2.0'
+  s.add_dependency "actionview", "~> 5.0"
+  s.add_dependency "addressable", ">= 2.3.8", "< 3"
+  s.add_dependency "govuk_publishing_components", ">= 16.16"
+  s.add_dependency "htmlentities", "~> 4"
+  s.add_dependency "i18n", "~> 0.7"
+  s.add_dependency "kramdown", "~> 1.15.0"
+  s.add_dependency "nokogiri", "~> 1.5"
+  s.add_dependency "nokogumbo", "~> 2"
+  s.add_dependency "rinku", "~> 2.0"
   s.add_dependency "sanitize", "~> 5"
 
-  s.add_development_dependency 'minitest', '~> 5.8.3'
-  s.add_development_dependency 'pry-byebug'
-  s.add_development_dependency 'rake', '~> 0.9.0'
-  s.add_development_dependency 'rubocop-govuk', '~> 1'
-  s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'simplecov-rcov'
+  s.add_development_dependency "minitest", "~> 5.8.3"
+  s.add_development_dependency "pry-byebug"
+  s.add_development_dependency "rake", "~> 0.9.0"
+  s.add_development_dependency "rubocop-govuk", "~> 1"
+  s.add_development_dependency "simplecov"
+  s.add_development_dependency "simplecov-rcov"
 end

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -1,32 +1,32 @@
-require 'active_support/core_ext/hash'
-require 'active_support/core_ext/array'
-require 'erb'
-require 'govuk_publishing_components'
-require 'htmlentities'
-require 'kramdown'
-require 'kramdown/parser/govuk'
-require 'nokogiri'
-require 'nokogumbo'
-require 'rinku'
-require 'sanitize'
-require 'govspeak/header_extractor'
-require 'govspeak/structured_header_extractor'
-require 'govspeak/html_validator'
-require 'govspeak/html_sanitizer'
-require 'govspeak/kramdown_overrides'
-require 'govspeak/blockquote_extra_quote_remover'
-require 'govspeak/post_processor'
-require 'govspeak/link_extractor'
-require 'govspeak/template_renderer'
-require 'govspeak/presenters/attachment_presenter'
-require 'govspeak/presenters/contact_presenter'
-require 'govspeak/presenters/h_card_presenter'
-require 'govspeak/presenters/image_presenter'
-require 'govspeak/presenters/attachment_image_presenter'
+require "active_support/core_ext/hash"
+require "active_support/core_ext/array"
+require "erb"
+require "govuk_publishing_components"
+require "htmlentities"
+require "kramdown"
+require "kramdown/parser/govuk"
+require "nokogiri"
+require "nokogumbo"
+require "rinku"
+require "sanitize"
+require "govspeak/header_extractor"
+require "govspeak/structured_header_extractor"
+require "govspeak/html_validator"
+require "govspeak/html_sanitizer"
+require "govspeak/kramdown_overrides"
+require "govspeak/blockquote_extra_quote_remover"
+require "govspeak/post_processor"
+require "govspeak/link_extractor"
+require "govspeak/template_renderer"
+require "govspeak/presenters/attachment_presenter"
+require "govspeak/presenters/contact_presenter"
+require "govspeak/presenters/h_card_presenter"
+require "govspeak/presenters/image_presenter"
+require "govspeak/presenters/attachment_image_presenter"
 
 module Govspeak
   def self.root
-    File.expand_path('..', File.dirname(__FILE__))
+    File.expand_path("..", File.dirname(__FILE__))
   end
 
   class Document
@@ -44,8 +44,8 @@ module Govspeak
       new(source, options).to_html
     end
 
-    def self.extensions
-      @extensions
+    class << self
+      attr_reader :extensions
     end
 
     def initialize(source, options = {})
@@ -118,7 +118,7 @@ module Govspeak
     def remove_forbidden_characters(source)
       # These are characters that are not deemed not suitable for
       # markup: https://www.w3.org/TR/unicode-xml/#Charlist
-      source.gsub(Sanitize::REGEX_UNSUITABLE_CHARS, '')
+      source.gsub(Sanitize::REGEX_UNSUITABLE_CHARS, "")
     end
 
     def self.extension(title, regexp = nil, &block)
@@ -147,7 +147,7 @@ module Govspeak
       parser.new(body.strip).to_html.sub(/^<p>(.*)<\/p>$/, "<p><strong>\\1</strong></p>")
     end
 
-    extension('button', %r{
+    extension("button", %r{
       (?:\r|\n|^) # non-capturing match to make sure start of line and linebreak
       {button(.*?)} # match opening bracket and capture attributes
         \s* # any whitespace between opening bracket and link
@@ -176,51 +176,51 @@ module Govspeak
       %{\n<a role="button" class="#{button_classes}" href="#{href}" #{data_attribute}>#{text}</a>\n}
     }
 
-    extension('highlight-answer') { |body|
+    extension("highlight-answer") { |body|
       %{\n\n<div class="highlight-answer">
 #{Govspeak::Document.new(body.strip).to_html}</div>\n}
     }
 
-    extension('stat-headline', %r${stat-headline}(.*?){/stat-headline}$m) { |body|
+    extension("stat-headline", %r${stat-headline}(.*?){/stat-headline}$m) { |body|
       %{\n\n<aside class="stat-headline">
 #{Govspeak::Document.new(body.strip).to_html}</aside>\n}
     }
 
     # FIXME: these surrounded_by arguments look dodgy
-    extension('external', surrounded_by("x[", ")x")) { |body|
+    extension("external", surrounded_by("x[", ")x")) { |body|
       Kramdown::Document.new("[#{body.strip}){:rel='external'}").to_html
     }
 
-    extension('informational', surrounded_by("^")) { |body|
+    extension("informational", surrounded_by("^")) { |body|
       %{\n\n<div role="note" aria-label="Information" class="application-notice info-notice">
 #{Govspeak::Document.new(body.strip).to_html}</div>\n}
     }
 
-    extension('important', surrounded_by("@")) { |body|
+    extension("important", surrounded_by("@")) { |body|
       %{\n\n<div role="note" aria-label="Important" class="advisory">#{insert_strong_inside_p(body)}</div>\n}
     }
 
-    extension('helpful', surrounded_by("%")) { |body|
+    extension("helpful", surrounded_by("%")) { |body|
       %{\n\n<div role="note" aria-label="Warning" class="application-notice help-notice">\n#{Govspeak::Document.new(body.strip).to_html}</div>\n}
     }
 
-    extension('barchart', /{barchart(.*?)}/) do |captures|
-      stacked = '.mc-stacked' if captures.include? 'stacked'
-      compact = '.compact' if captures.include? 'compact'
-      negative = '.mc-negative' if captures.include? 'negative'
+    extension("barchart", /{barchart(.*?)}/) do |captures|
+      stacked = ".mc-stacked" if captures.include? "stacked"
+      compact = ".compact" if captures.include? "compact"
+      negative = ".mc-negative" if captures.include? "negative"
 
       [
-       '{:',
-       '.js-barchart-table',
+       "{:",
+       ".js-barchart-table",
        stacked,
        compact,
        negative,
-       '.mc-auto-outdent',
-       '}'
-      ].join(' ')
+       ".mc-auto-outdent",
+       "}",
+      ].join(" ")
     end
 
-    extension('attached-image', /^!!([0-9]+)/) do |image_number|
+    extension("attached-image", /^!!([0-9]+)/) do |image_number|
       image = images[image_number.to_i - 1]
       next "" unless image
 
@@ -228,7 +228,7 @@ module Govspeak
     end
 
     # DEPRECATED: use 'AttachmentLink:attachment-id' instead
-    extension('embed attachment inline', /\[embed:attachments:inline:\s*(.*?)\s*\]/) do |content_id|
+    extension("embed attachment inline", /\[embed:attachments:inline:\s*(.*?)\s*\]/) do |content_id|
       attachment = attachments.detect { |a| a[:content_id] == content_id }
       next "" unless attachment
 
@@ -243,7 +243,7 @@ module Govspeak
     end
 
     # DEPRECATED: use 'Image:image-id' instead
-    extension('attachment image', /\[embed:attachments:image:\s*(.*?)\s*\]/) do |content_id|
+    extension("attachment image", /\[embed:attachments:image:\s*(.*?)\s*\]/) do |content_id|
       attachment = attachments.detect { |a| a[:content_id] == content_id }
       next "" unless attachment
 
@@ -266,29 +266,29 @@ module Govspeak
       lines << %{<figure#{id_attr} class="image embedded">}
       lines << %{<div class="img"><img src="#{encode(image.url)}" alt="#{encode(image.alt_text)}"></div>}
       lines << image.figcaption_html if image.figcaption?
-      lines << '</figure>'
+      lines << "</figure>"
       lines.join
     end
 
-    wrap_with_div('summary', '$!')
-    wrap_with_div('form-download', '$D')
-    wrap_with_div('contact', '$C')
-    wrap_with_div('place', '$P', Govspeak::Document)
-    wrap_with_div('information', '$I', Govspeak::Document)
-    wrap_with_div('additional-information', '$AI')
-    wrap_with_div('example', '$E', Govspeak::Document)
-    wrap_with_div('call-to-action', '$CTA', Govspeak::Document)
+    wrap_with_div("summary", "$!")
+    wrap_with_div("form-download", "$D")
+    wrap_with_div("contact", "$C")
+    wrap_with_div("place", "$P", Govspeak::Document)
+    wrap_with_div("information", "$I", Govspeak::Document)
+    wrap_with_div("additional-information", "$AI")
+    wrap_with_div("example", "$E", Govspeak::Document)
+    wrap_with_div("call-to-action", "$CTA", Govspeak::Document)
 
-    extension('address', surrounded_by("$A")) { |body|
+    extension("address", surrounded_by("$A")) { |body|
       %{\n<div class="address"><div class="adr org fn"><p>\n#{body.sub("\n", '').gsub("\n", '<br />')}\n</p></div></div>\n}
     }
 
     extension("legislative list", /#{NEW_PARAGRAPH_LOOKBEHIND}\$LegislativeList\s*$(.*?)\$EndLegislativeList/m) do |body|
       Govspeak::KramdownOverrides.with_kramdown_ordered_lists_disabled do
         Kramdown::Document.new(body.strip).to_html.tap do |doc|
-          doc.gsub!('<ul>', '<ol>')
-          doc.gsub!('</ul>', '</ol>')
-          doc.sub!('<ol>', '<ol class="legislative-list">')
+          doc.gsub!("<ul>", "<ol>")
+          doc.gsub!("</ul>", "</ol>")
+          doc.sub!("<ol>", '<ol class="legislative-list">')
         end
       end
     end
@@ -301,12 +301,12 @@ module Govspeak
     end
 
     def self.devolved_options
-      { 'scotland' => 'Scotland',
-        'england' => 'England',
-        'england-wales' => 'England and Wales',
-        'northern-ireland' => 'Northern Ireland',
-        'wales' => 'Wales',
-        'london' => 'London' }
+      { "scotland" => "Scotland",
+        "england" => "England",
+        "england-wales" => "England and Wales",
+        "northern-ireland" => "Northern Ireland",
+        "wales" => "Wales",
+        "london" => "London" }
     end
 
     devolved_options.each do |k, v|
@@ -333,7 +333,7 @@ module Govspeak
       end
     end
 
-    extension('embed link', /\[embed:link:\s*(.*?)\s*\]/) do |content_id|
+    extension("embed link", /\[embed:link:\s*(.*?)\s*\]/) do |content_id|
       link = links.detect { |l| l[:content_id] == content_id }
       next "" unless link
 
@@ -344,28 +344,28 @@ module Govspeak
       end
     end
 
-    extension('Contact', /\[Contact:\s*(.*?)\s*\]/) do |content_id|
+    extension("Contact", /\[Contact:\s*(.*?)\s*\]/) do |content_id|
       contact = contacts.detect { |c| c[:content_id] == content_id }
       next "" unless contact
 
-      renderer = TemplateRenderer.new('contact.html.erb', locale)
+      renderer = TemplateRenderer.new("contact.html.erb", locale)
       renderer.render(contact: ContactPresenter.new(contact))
     end
 
-    extension('Image', /#{NEW_PARAGRAPH_LOOKBEHIND}\[Image:\s*(.*?)\s*\]/) do |image_id|
+    extension("Image", /#{NEW_PARAGRAPH_LOOKBEHIND}\[Image:\s*(.*?)\s*\]/) do |image_id|
       image = images.detect { |c| c.is_a?(Hash) && c[:id] == image_id }
       next "" unless image
 
       render_image(ImagePresenter.new(image))
     end
 
-    extension('Attachment', /#{NEW_PARAGRAPH_LOOKBEHIND}\[Attachment:\s*(.*?)\s*\]/) do |attachment_id|
+    extension("Attachment", /#{NEW_PARAGRAPH_LOOKBEHIND}\[Attachment:\s*(.*?)\s*\]/) do |attachment_id|
       next "" if attachments.none? { |a| a[:id] == attachment_id }
 
       %{<govspeak-embed-attachment id="#{attachment_id}"></govspeak-embed-attachment>}
     end
 
-    extension('AttachmentLink', /\[AttachmentLink:\s*(.*?)\s*\]/) do |attachment_id|
+    extension("AttachmentLink", /\[AttachmentLink:\s*(.*?)\s*\]/) do |attachment_id|
       next "" if attachments.none? { |a| a[:id] == attachment_id }
 
       %{<govspeak-embed-attachment-link id="#{attachment_id}"></govspeak-embed-attachment-link>}
@@ -384,5 +384,5 @@ module Govspeak
 end
 
 I18n.load_path.unshift(
-  *Dir.glob(File.expand_path('locales/*.yml', Govspeak.root))
+  *Dir.glob(File.expand_path("locales/*.yml", Govspeak.root)),
 )

--- a/lib/govspeak/header_extractor.rb
+++ b/lib/govspeak/header_extractor.rb
@@ -20,7 +20,7 @@ module Govspeak
   private
 
     def id(element)
-      element.attr.fetch('id', generate_id(element.options[:raw_text]))
+      element.attr.fetch("id", generate_id(element.options[:raw_text]))
     end
 
     def build_header(element)

--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -1,4 +1,4 @@
-require 'addressable/uri'
+require "addressable/uri"
 
 class Govspeak::HtmlSanitizer
   class ImageSourceWhitelister
@@ -10,7 +10,7 @@ class Govspeak::HtmlSanitizer
       return unless sanitize_context[:node_name] == "img"
 
       node = sanitize_context[:node]
-      image_uri = Addressable::URI.parse(node['src'])
+      image_uri = Addressable::URI.parse(node["src"])
       unless image_uri.relative? || @allowed_image_hosts.include?(image_uri.host)
         node.unlink # the node isn't sanitary. Remove it from the document.
       end
@@ -25,8 +25,8 @@ class Govspeak::HtmlSanitizer
 
       # Kramdown uses text-align to allow table cells to be aligned
       # http://kramdown.gettalong.org/quickref.html#tables
-      if invalid_style_attribute?(node['style'])
-        node.remove_attribute('style')
+      if invalid_style_attribute?(node["style"])
+        node.remove_attribute("style")
       end
     end
 
@@ -58,7 +58,7 @@ class Govspeak::HtmlSanitizer
         "th"  => Sanitize::Config::RELAXED[:attributes]["th"] + %w[style],
         "td"  => Sanitize::Config::RELAXED[:attributes]["td"] + %w[style],
         "govspeak-embed-attachment" => %w[content-id],
-      }
+      },
     )
   end
 end

--- a/lib/govspeak/link_extractor.rb
+++ b/lib/govspeak/link_extractor.rb
@@ -20,8 +20,8 @@ module Govspeak
     end
 
     def extract_href_from_link(link)
-      href = link['href'] || ''
-      if website_root && href.start_with?('/')
+      href = link["href"] || ""
+      if website_root && href.start_with?("/")
         "#{website_root}#{href}"
       else
         href
@@ -29,7 +29,7 @@ module Govspeak
     end
 
     def document_anchors
-      processed_govspeak.css('a[href]').css('a:not([href^="mailto"])').css('a:not([href^="#"])')
+      processed_govspeak.css("a[href]").css('a:not([href^="mailto"])').css('a:not([href^="#"])')
     end
 
     def processed_govspeak

--- a/lib/govspeak/post_processor.rb
+++ b/lib/govspeak/post_processor.rb
@@ -2,8 +2,8 @@ module Govspeak
   class PostProcessor
     @extensions = []
 
-    def self.extensions
-      @extensions
+    class << self
+      attr_reader :extensions
     end
 
     def self.process(html, govspeak_document)
@@ -38,11 +38,11 @@ module Govspeak
         el.children = xml
           .gsub(
             %r{&lt;(div class="img")&gt;(.*?)&lt;(/div)&gt;},
-            "<\\1>\\2<\\3>"
+            "<\\1>\\2<\\3>",
           )
           .gsub(
             %r{&lt;(figcaption)&gt;(.*?)&lt;(/figcaption&)gt;},
-            "<\\1>\\2<\\3>"
+            "<\\1>\\2<\\3>",
           )
       end
     end
@@ -59,7 +59,7 @@ module Govspeak
         attachment_html = GovukPublishingComponents.render(
           "govuk_publishing_components/components/attachment",
           attachment: attachment,
-          locale: govspeak_document.locale
+          locale: govspeak_document.locale,
         )
         el.swap(attachment_html)
       end
@@ -77,7 +77,7 @@ module Govspeak
         attachment_html = GovukPublishingComponents.render(
           "govuk_publishing_components/components/attachment_link",
           attachment: attachment,
-          locale: govspeak_document.locale
+          locale: govspeak_document.locale,
         )
         el.swap(attachment_html)
       end
@@ -85,17 +85,17 @@ module Govspeak
 
     extension("Add table headers and row / column scopes") do |document|
       document.css("thead th").map do |el|
-        el.content = el.content.gsub(/^# /, '')
-        el.content = el.content.gsub(/[[:space:]]/, '') if el.content.blank? # Removes a strange whitespace in the cell if the cell is already blank.
-        el.name = 'td' if el.content.blank? # This prevents a `th` with nothing inside it; a `td` is preferable.
+        el.content = el.content.gsub(/^# /, "")
+        el.content = el.content.gsub(/[[:space:]]/, "") if el.content.blank? # Removes a strange whitespace in the cell if the cell is already blank.
+        el.name = "td" if el.content.blank? # This prevents a `th` with nothing inside it; a `td` is preferable.
         el[:scope] = "col" if el.content.present? # `scope` shouldn't be used if there's nothing in the table heading.
       end
 
       document.css(":not(thead) tr td:first-child").map do |el|
         if el.content.match?(/^#($|\s.*$)/)
-          el.content = el.content.gsub(/^#($|\s)/, '') # Replace '# ' and '#', but not '#Word'.
-          el.name = 'th' if el.content.present? # This also prevents a `th` with nothing inside it; a `td` is preferable.
-          el[:scope] = 'row' if el.content.present? # `scope` shouldn't be used if there's nothing in the table heading.
+          el.content = el.content.gsub(/^#($|\s)/, "") # Replace '# ' and '#', but not '#Word'.
+          el.name = "th" if el.content.present? # This also prevents a `th` with nothing inside it; a `td` is preferable.
+          el[:scope] = "row" if el.content.present? # `scope` shouldn't be used if there's nothing in the table heading.
         end
       end
     end

--- a/lib/govspeak/presenters/attachment_presenter.rb
+++ b/lib/govspeak/presenters/attachment_presenter.rb
@@ -34,15 +34,15 @@ module Govspeak
     def attachment_attributes
       attributes = []
       if file_extension == "html"
-        attributes << content_tag(:span, 'HTML', class: 'type')
+        attributes << content_tag(:span, "HTML", class: "type")
       elsif attachment[:external?]
-        attributes << content_tag(:span, url, class: 'url')
+        attributes << content_tag(:span, url, class: "url")
       else
-        attributes << content_tag(:span, humanized_content_type(file_extension), class: 'type') if file_extension
-        attributes << content_tag(:span, number_to_human_size(attachment[:file_size]), class: 'file-size') if attachment[:file_size]
-        attributes << content_tag(:span, pluralize(attachment[:number_of_pages], "page"), class: 'page-length') if attachment[:number_of_pages]
+        attributes << content_tag(:span, humanized_content_type(file_extension), class: "type") if file_extension
+        attributes << content_tag(:span, number_to_human_size(attachment[:file_size]), class: "file-size") if attachment[:file_size]
+        attributes << content_tag(:span, pluralize(attachment[:number_of_pages], "page"), class: "page-length") if attachment[:number_of_pages]
       end
-      attributes.join(', ').html_safe
+      attributes.join(", ").html_safe
     end
 
     MS_WORD_DOCUMENT_HUMANIZED_CONTENT_TYPE = "MS Word Document".freeze
@@ -55,41 +55,41 @@ module Govspeak
 
     def humanized_content_type(file_extension)
       file_extension_vs_humanized_content_type = {
-        "chm"  => file_abbr_tag('CHM', 'Microsoft Compiled HTML Help'),
-        "csv"  => file_abbr_tag('CSV', 'Comma-separated Values'),
-        "diff" => file_abbr_tag('DIFF', 'Plain text differences'),
+        "chm"  => file_abbr_tag("CHM", "Microsoft Compiled HTML Help"),
+        "csv"  => file_abbr_tag("CSV", "Comma-separated Values"),
+        "diff" => file_abbr_tag("DIFF", "Plain text differences"),
         "doc"  => MS_WORD_DOCUMENT_HUMANIZED_CONTENT_TYPE,
         "docx" => MS_WORD_DOCUMENT_HUMANIZED_CONTENT_TYPE,
-        "dot"  => file_abbr_tag('DOT', 'MS Word Document Template'),
-        "dxf"  => file_abbr_tag('DXF', 'AutoCAD Drawing Exchange Format'),
-        "eps"  => file_abbr_tag('EPS', 'Encapsulated PostScript'),
-        "gif"  => file_abbr_tag('GIF', 'Graphics Interchange Format'),
-        "gml"  => file_abbr_tag('GML', 'Geography Markup Language'),
-        "html" => file_abbr_tag('HTML', 'Hypertext Markup Language'),
-        "ics" => file_abbr_tag('ICS', 'iCalendar file'),
+        "dot"  => file_abbr_tag("DOT", "MS Word Document Template"),
+        "dxf"  => file_abbr_tag("DXF", "AutoCAD Drawing Exchange Format"),
+        "eps"  => file_abbr_tag("EPS", "Encapsulated PostScript"),
+        "gif"  => file_abbr_tag("GIF", "Graphics Interchange Format"),
+        "gml"  => file_abbr_tag("GML", "Geography Markup Language"),
+        "html" => file_abbr_tag("HTML", "Hypertext Markup Language"),
+        "ics" => file_abbr_tag("ICS", "iCalendar file"),
         "jpg"  => "JPEG",
-        "odp"  => file_abbr_tag('ODP', 'OpenDocument Presentation'),
-        "ods"  => file_abbr_tag('ODS', 'OpenDocument Spreadsheet'),
-        "odt"  => file_abbr_tag('ODT', 'OpenDocument Text document'),
-        "pdf"  => file_abbr_tag('PDF', 'Portable Document Format'),
-        "png"  => file_abbr_tag('PNG', 'Portable Network Graphic'),
+        "odp"  => file_abbr_tag("ODP", "OpenDocument Presentation"),
+        "ods"  => file_abbr_tag("ODS", "OpenDocument Spreadsheet"),
+        "odt"  => file_abbr_tag("ODT", "OpenDocument Text document"),
+        "pdf"  => file_abbr_tag("PDF", "Portable Document Format"),
+        "png"  => file_abbr_tag("PNG", "Portable Network Graphic"),
         "ppt"  => MS_POWERPOINT_PRESENTATION_HUMANIZED_CONTENT_TYPE,
         "pptx" => MS_POWERPOINT_PRESENTATION_HUMANIZED_CONTENT_TYPE,
-        "ps"   => file_abbr_tag('PS', 'PostScript'),
-        "rdf"  => file_abbr_tag('RDF', 'Resource Description Framework'),
-        "rtf"  => file_abbr_tag('RTF', 'Rich Text Format'),
-        "sch"  => file_abbr_tag('SCH', 'XML based Schematic'),
+        "ps"   => file_abbr_tag("PS", "PostScript"),
+        "rdf"  => file_abbr_tag("RDF", "Resource Description Framework"),
+        "rtf"  => file_abbr_tag("RTF", "Rich Text Format"),
+        "sch"  => file_abbr_tag("SCH", "XML based Schematic"),
         "txt"  => "Plain text",
-        "wsdl" => file_abbr_tag('WSDL', 'Web Services Description Language'),
+        "wsdl" => file_abbr_tag("WSDL", "Web Services Description Language"),
         "xls"  => MS_EXCEL_SPREADSHEET_HUMANIZED_CONTENT_TYPE,
-        "xlsm" => file_abbr_tag('XLSM', 'MS Excel Macro-Enabled Workbook'),
+        "xlsm" => file_abbr_tag("XLSM", "MS Excel Macro-Enabled Workbook"),
         "xlsx" => MS_EXCEL_SPREADSHEET_HUMANIZED_CONTENT_TYPE,
-        "xlt"  => file_abbr_tag('XLT', 'MS Excel Spreadsheet Template'),
-        "xsd"  => file_abbr_tag('XSD', 'XML Schema'),
-        "xslt" => file_abbr_tag('XSLT', 'Extensible Stylesheet Language Transformation'),
-        "zip"  => file_abbr_tag('ZIP', 'Zip archive'),
+        "xlt"  => file_abbr_tag("XLT", "MS Excel Spreadsheet Template"),
+        "xsd"  => file_abbr_tag("XSD", "XML Schema"),
+        "xslt" => file_abbr_tag("XSLT", "Extensible Stylesheet Language Transformation"),
+        "zip"  => file_abbr_tag("ZIP", "Zip archive"),
       }
-      file_extension_vs_humanized_content_type.fetch(file_extension.to_s.downcase, '')
+      file_extension_vs_humanized_content_type.fetch(file_extension.to_s.downcase, "")
     end
 
     def link(body, url, options = {})

--- a/lib/govspeak/presenters/contact_presenter.rb
+++ b/lib/govspeak/presenters/contact_presenter.rb
@@ -1,5 +1,5 @@
-require 'active_support/core_ext/array'
-require 'active_support/core_ext/hash'
+require "active_support/core_ext/array"
+require "active_support/core_ext/hash"
 
 module Govspeak
   class ContactPresenter

--- a/lib/govspeak/presenters/h_card_presenter.rb
+++ b/lib/govspeak/presenters/h_card_presenter.rb
@@ -2,7 +2,7 @@ module Govspeak
   class HCardPresenter
     def self.address_formats
       @address_formats ||= YAML.load_file(
-        File.expand_path('config/address_formats.yml', Govspeak.root)
+        File.expand_path("config/address_formats.yml", Govspeak.root),
       )
     end
 
@@ -44,7 +44,7 @@ module Govspeak
         address.gsub!(/\{\{#{hcard_name}\}\}/, interpolate_address_property(our_name, hcard_name))
       end
 
-      address.gsub(/^\n/, '')         # get  rid of blank lines
+      address.gsub(/^\n/, "")         # get  rid of blank lines
              .strip                   # get rid of any trailing whitespace
              .gsub(/\n/, "<br />\n")  # add break tags where appropriate
     end
@@ -55,7 +55,7 @@ module Govspeak
     end
 
     def default_format_string
-      self.class.address_formats['gb']
+      self.class.address_formats["gb"]
     end
   end
 end

--- a/lib/govspeak/presenters/image_presenter.rb
+++ b/lib/govspeak/presenters/image_presenter.rb
@@ -32,10 +32,10 @@ module Govspeak
 
     def figcaption_html
       lines = []
-      lines << '<figcaption>'
+      lines << "<figcaption>"
       lines << %{<p>#{caption}</p>} if caption.present?
       lines << %{<p>#{I18n.t('govspeak.image.figure.credit', credit: credit)}</p>} if credit.present?
-      lines << '</figcaption>'
+      lines << "</figcaption>"
       lines.join
     end
   end

--- a/lib/kramdown/parser/govuk.rb
+++ b/lib/kramdown/parser/govuk.rb
@@ -33,7 +33,7 @@ module Kramdown
           begin
             host = Addressable::URI.parse(href).host
             unless host.nil? || @document_domains.compact.include?(host)
-              element.attr['rel'] = 'external'
+              element.attr["rel"] = "external"
             end
           # rubocop:disable Lint/HandleExceptions
           rescue Addressable::URI::InvalidURIError

--- a/test/blockquote_extra_quote_remover_test.rb
+++ b/test/blockquote_extra_quote_remover_test.rb
@@ -28,67 +28,67 @@ class BlockquoteExtraQuoteRemoverTest < Minitest::Test
   test "transforms text with surrounding quotes" do
     assert_remover_transforms(
       %{He said:\n> "yes, it's true!"\n\napparently.} =>
-      %{He said:\n> yes, it's true!\n\napparently.}
+      %{He said:\n> yes, it's true!\n\napparently.},
     )
   end
 
   test "leaves quotes in the middle of the string" do
     assert_remover_transforms(
       %{He said:\n> "yes, it's true!" whilst sipping a cocktail. "And yes, I did rather enjoy it." \n\napparently.} =>
-      %{He said:\n> yes, it's true!" whilst sipping a cocktail. "And yes, I did rather enjoy it.\n\napparently.}
+      %{He said:\n> yes, it's true!" whilst sipping a cocktail. "And yes, I did rather enjoy it.\n\napparently.},
     )
   end
 
   test "leaves trailing text and quote intact" do
     assert_remover_transforms(
       %{He said:\n> "yes, it's true!" whilst sipping a cocktail.} =>
-      %{He said:\n> yes, it's true!" whilst sipping a cocktail.}
+      %{He said:\n> yes, it's true!" whilst sipping a cocktail.},
     )
   end
 
   test "windows line breaks" do
     assert_remover_transforms(
       %{Sir George Young MP, said\r\n>  "I welcome the positive public response to the e-petitions site, which is important way of building a bridge between people and Parliament.”\r\n## The special relationship} =>
-      %{Sir George Young MP, said\r\n> I welcome the positive public response to the e-petitions site, which is important way of building a bridge between people and Parliament.\r\n## The special relationship}
+      %{Sir George Young MP, said\r\n> I welcome the positive public response to the e-petitions site, which is important way of building a bridge between people and Parliament.\r\n## The special relationship},
     )
   end
 
   test "no space in front" do
     assert_remover_transforms(
       %{>"As we continue with the redundancy process we will ensure we retain the capabilities that our armed forces will require to meet the challenges of the future. The redundancy programme will not impact adversely on the current operations in Afghanistan, where our armed forces continue to fight so bravely on this country's behalf."} =>
-      %{> As we continue with the redundancy process we will ensure we retain the capabilities that our armed forces will require to meet the challenges of the future. The redundancy programme will not impact adversely on the current operations in Afghanistan, where our armed forces continue to fight so bravely on this country's behalf.}
+      %{> As we continue with the redundancy process we will ensure we retain the capabilities that our armed forces will require to meet the challenges of the future. The redundancy programme will not impact adversely on the current operations in Afghanistan, where our armed forces continue to fight so bravely on this country's behalf.},
     )
   end
 
   test "handles space after a quote" do
     assert_remover_transforms(
       %{>" Test"} =>
-      %{> Test}
+      %{> Test},
     )
   end
 
   test "remove double double quotes" do
     assert_remover_transforms(
       %{We heard it said:\n\n> ""Today the coalition is remedying those deficiencies by putting in place a new fast track process where the people's elected representatives have responsibility for the final decisions about Britain's future instead of unelected commissioners.""} =>
-      %{We heard it said:\n\n> Today the coalition is remedying those deficiencies by putting in place a new fast track process where the people's elected representatives have responsibility for the final decisions about Britain's future instead of unelected commissioners.}
+      %{We heard it said:\n\n> Today the coalition is remedying those deficiencies by putting in place a new fast track process where the people's elected representatives have responsibility for the final decisions about Britain's future instead of unelected commissioners.},
     )
     assert_remover_transforms(
       %{> ""Today the coalition is remedying those deficiencies by putting in place a new fast track process where the people's elected representatives have responsibility for the final decisions about Britain's future instead of unelected commissioners.} =>
-      %{> Today the coalition is remedying those deficiencies by putting in place a new fast track process where the people's elected representatives have responsibility for the final decisions about Britain's future instead of unelected commissioners.}
+      %{> Today the coalition is remedying those deficiencies by putting in place a new fast track process where the people's elected representatives have responsibility for the final decisions about Britain's future instead of unelected commissioners.},
     )
   end
 
   test "removes quotes correctly from multi-line blockquotes" do
     assert_remover_transforms(
       %{> "Here is a block quote using 2 lines and two of the arrows.\n> I am not sure how this will render.  I think it will mash them together."} =>
-      %{> Here is a block quote using 2 lines and two of the arrows.\n> I am not sure how this will render.  I think it will mash them together.}
+      %{> Here is a block quote using 2 lines and two of the arrows.\n> I am not sure how this will render.  I think it will mash them together.},
     )
   end
 
   test "preserves multiline blockquotes with plain newlines quotes" do
     assert_remover_transforms(
       %{> "line 1\n> \n> "line 2\n> \n> "line 3"} =>
-      %{> line 1\n> \n> line 2\n> \n> line 3}
+      %{> line 1\n> \n> line 2\n> \n> line 3},
       )
   end
 

--- a/test/govspeak_attachments_image_test.rb
+++ b/test/govspeak_attachments_image_test.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
 
-require 'test_helper'
+require "test_helper"
 
 class GovspeakAttachmentsImageTest < Minitest::Test
   def build_attachment(args = {})
@@ -17,7 +17,7 @@ class GovspeakAttachmentsImageTest < Minitest::Test
   end
 
   def compress_html(html)
-    html.gsub(/[\n\r]+[\s]*/, '')
+    html.gsub(/[\n\r]+[\s]*/, "")
   end
 
   test "renders an empty string for an image attachment not found" do
@@ -27,7 +27,7 @@ class GovspeakAttachmentsImageTest < Minitest::Test
   test "wraps an attachment in a figure with the id if the id is present" do
     rendered = render_govspeak(
       "[embed:attachments:image:1fe8]",
-      [build_attachment(id: 10, content_id: "1fe8")]
+      [build_attachment(id: 10, content_id: "1fe8")],
     )
     assert_match(/<figure id="attachment_10" class="image embedded">/, rendered)
   end
@@ -35,7 +35,7 @@ class GovspeakAttachmentsImageTest < Minitest::Test
   test "wraps an attachment in a figure without the id if the id is not present" do
     rendered = render_govspeak(
       "[embed:attachments:image:1fe8]",
-      [build_attachment(id: nil, content_id: "1fe8")]
+      [build_attachment(id: nil, content_id: "1fe8")],
     )
     assert_match(/<figure class="image embedded">/, rendered)
   end
@@ -43,7 +43,7 @@ class GovspeakAttachmentsImageTest < Minitest::Test
   test "renders an attachment if there are spaces around the content_id" do
     rendered = render_govspeak(
       "[embed:attachments:image: 1fe8 ]",
-      [build_attachment(id: 10, content_id: "1fe8")]
+      [build_attachment(id: 10, content_id: "1fe8")],
     )
     assert_match(/<figure id="attachment_10" class="image embedded">/, rendered)
   end
@@ -51,7 +51,7 @@ class GovspeakAttachmentsImageTest < Minitest::Test
   test "has an image element to the file" do
     rendered = render_govspeak(
       "[embed:attachments:image:1fe8]",
-      [build_attachment(id: nil, url: "http://a.b/c.jpg", content_id: "1fe8")]
+      [build_attachment(id: nil, url: "http://a.b/c.jpg", content_id: "1fe8")],
     )
     assert_match(%r{<img.*src="http://a.b/c.jpg"}, rendered)
   end
@@ -59,7 +59,7 @@ class GovspeakAttachmentsImageTest < Minitest::Test
   test "renders the image title as an alt tag" do
     rendered = render_govspeak(
       "[embed:attachments:image:1fe8]",
-      [build_attachment(id: nil, title: "My Title", content_id: "1fe8")]
+      [build_attachment(id: nil, title: "My Title", content_id: "1fe8")],
     )
     assert_match(%r{<img.*alt="My Title"}, rendered)
   end
@@ -67,7 +67,7 @@ class GovspeakAttachmentsImageTest < Minitest::Test
   test "can render a nil image title" do
     rendered = render_govspeak(
       "[embed:attachments:image:1fe8]",
-      [build_attachment(id: nil, title: nil, content_id: "1fe8")]
+      [build_attachment(id: nil, title: nil, content_id: "1fe8")],
     )
     assert_match(%r{<img.*alt=""}, rendered)
   end
@@ -75,7 +75,7 @@ class GovspeakAttachmentsImageTest < Minitest::Test
   test "a full image attachment rendering looks correct" do
     rendered = render_govspeak(
       "[embed:attachments:image:1fe8]",
-      [build_attachment(id: 10, url: "http://a.b/c.jpg", title: "My Title", content_id: "1fe8")]
+      [build_attachment(id: 10, url: "http://a.b/c.jpg", title: "My Title", content_id: "1fe8")],
     )
     expected_html_output = %{
       <figure id="attachment_10" class="image embedded">
@@ -89,7 +89,7 @@ class GovspeakAttachmentsImageTest < Minitest::Test
   test "can be rendered inside a table" do
     rendered = render_govspeak(
       "| [embed:attachments:image:1fe8] |",
-      [build_attachment(content_id: "1fe8", id: nil)]
+      [build_attachment(content_id: "1fe8", id: nil)],
     )
 
     regex = %r{<td><figure class="image embedded"><div class="img">(.*?)</div></figure></td>}

--- a/test/govspeak_attachments_inline_test.rb
+++ b/test/govspeak_attachments_inline_test.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
 
-require 'test_helper'
+require "test_helper"
 
 class GovspeakAttachmentsInlineTest < Minitest::Test
   def build_attachment(args = {})
@@ -23,7 +23,7 @@ class GovspeakAttachmentsInlineTest < Minitest::Test
   test "wraps an attachment in a span with the id if the id is present" do
     rendered = render_govspeak(
       "[embed:attachments:inline:1fe8]",
-      [build_attachment(id: 10, content_id: "1fe8")]
+      [build_attachment(id: 10, content_id: "1fe8")],
     )
     assert_match(/<span id="attachment_10" class="attachment-inline">/, rendered)
   end
@@ -31,7 +31,7 @@ class GovspeakAttachmentsInlineTest < Minitest::Test
   test "wraps an attachment in a span without the id if the id is not present" do
     rendered = render_govspeak(
       "[embed:attachments:inline:1fe8]",
-      [build_attachment(id: nil, content_id: "1fe8")]
+      [build_attachment(id: nil, content_id: "1fe8")],
     )
     assert_match(/<span class="attachment-inline">/, rendered)
   end
@@ -39,7 +39,7 @@ class GovspeakAttachmentsInlineTest < Minitest::Test
   test "renders an attachment where the content id has spaces" do
     rendered = render_govspeak(
       "[embed:attachments:inline:  1fe8  ]",
-      [build_attachment(id: nil, content_id: "1fe8")]
+      [build_attachment(id: nil, content_id: "1fe8")],
     )
     assert_match(/<span class="attachment-inline">/, rendered)
   end
@@ -47,7 +47,7 @@ class GovspeakAttachmentsInlineTest < Minitest::Test
   test "links to the attachment file" do
     rendered = render_govspeak(
       "[embed:attachments:inline:1fe8]",
-      [build_attachment(content_id: "1fe8", url: "http://a.b/f.pdf", title: "My Pdf")]
+      [build_attachment(content_id: "1fe8", url: "http://a.b/f.pdf", title: "My Pdf")],
     )
     assert_match(%r{<a href="http://a.b/f.pdf">My Pdf</a>}, rendered)
   end
@@ -55,7 +55,7 @@ class GovspeakAttachmentsInlineTest < Minitest::Test
   test "renders with a nil title" do
     rendered = render_govspeak(
       "[embed:attachments:inline:1fe8]",
-      [build_attachment(content_id: "1fe8", url: "http://a.b/f.pdf", title: nil)]
+      [build_attachment(content_id: "1fe8", url: "http://a.b/f.pdf", title: nil)],
     )
     assert_match(%r{<a href="http://a.b/f.pdf"></a>}, rendered)
   end
@@ -63,7 +63,7 @@ class GovspeakAttachmentsInlineTest < Minitest::Test
   test "renders on a single line" do
     rendered = render_govspeak(
       "[embed:attachments:inline:2bc1]",
-      [build_attachment(content_id: "2bc1", external?: true)]
+      [build_attachment(content_id: "2bc1", external?: true)],
     )
     assert_match(%r{<span id="attachment[^\n]*</span>}, rendered)
   end
@@ -71,7 +71,7 @@ class GovspeakAttachmentsInlineTest < Minitest::Test
   test "doesn't have spaces between the span and the link" do
     rendered = render_govspeak(
       "[embed:attachments:inline:2bc1]",
-      [build_attachment(content_id: "2bc1", id: nil)]
+      [build_attachment(content_id: "2bc1", id: nil)],
     )
     assert_match(%r{<span class="attachment-inline"><a href=".*">.*</a></span>}, rendered)
   end
@@ -79,7 +79,7 @@ class GovspeakAttachmentsInlineTest < Minitest::Test
   test "will show HTML type (in brackets) if file_extension is specified as html" do
     rendered = render_govspeak(
       "[embed:attachments:inline:1fe8]",
-      [build_attachment(content_id: "1fe8", file_extension: "html")]
+      [build_attachment(content_id: "1fe8", file_extension: "html")],
     )
     assert_match(%r{(<span class="type">HTML</span>)}, rendered)
   end
@@ -87,7 +87,7 @@ class GovspeakAttachmentsInlineTest < Minitest::Test
   test "will show url (in brackets) if specified as external" do
     rendered = render_govspeak(
       "[embed:attachments:inline:1fe8]",
-      [build_attachment(content_id: "1fe8", url: "http://a.b/f.pdf", external?: true)]
+      [build_attachment(content_id: "1fe8", url: "http://a.b/f.pdf", external?: true)],
     )
     assert_match(%r{(<span class="url">http://a.b/f.pdf</span>)}, rendered)
   end
@@ -95,7 +95,7 @@ class GovspeakAttachmentsInlineTest < Minitest::Test
   test "will not show url if file_extension is specified as html" do
     rendered = render_govspeak(
       "[embed:attachments:inline:1fe8]",
-      [build_attachment(content_id: "1fe8", url: "http://a.b/f.pdf", file_extension: "html", external?: true)]
+      [build_attachment(content_id: "1fe8", url: "http://a.b/f.pdf", file_extension: "html", external?: true)],
     )
     refute_match(%r{(<span class="url">http://a.b/f.pdf</span>)}, rendered)
   end
@@ -103,7 +103,7 @@ class GovspeakAttachmentsInlineTest < Minitest::Test
   test "will show a file extension in a abbr element for non html" do
     rendered = render_govspeak(
       "[embed:attachments:inline:1fe8]",
-      [build_attachment(content_id: "1fe8", file_extension: "csv")]
+      [build_attachment(content_id: "1fe8", file_extension: "csv")],
     )
     refute_match(%r{<span class="type"><abbr title="Comma-separated values">CSV</abbr></span>}, rendered)
   end
@@ -111,7 +111,7 @@ class GovspeakAttachmentsInlineTest < Minitest::Test
   test "will show file size in a span" do
     rendered = render_govspeak(
       "[embed:attachments:inline:1fe8]",
-      [build_attachment(content_id: "1fe8", file_size: 1024)]
+      [build_attachment(content_id: "1fe8", file_size: 1024)],
     )
     assert_match(%r{<span class="file-size">1 KB</span>}, rendered)
   end
@@ -119,12 +119,12 @@ class GovspeakAttachmentsInlineTest < Minitest::Test
   test "will show number of pages" do
     rendered = render_govspeak(
       "[embed:attachments:inline:1fe8]",
-      [build_attachment(content_id: "1fe8", number_of_pages: 1)]
+      [build_attachment(content_id: "1fe8", number_of_pages: 1)],
     )
     assert_match(%r{<span class="page-length">1 page</span>}, rendered)
     rendered = render_govspeak(
       "[embed:attachments:inline:1fe8]",
-      [build_attachment(content_id: "1fe8", number_of_pages: 2)]
+      [build_attachment(content_id: "1fe8", number_of_pages: 2)],
     )
     assert_match(%r{<span class="page-length">2 pages</span>}, rendered)
   end
@@ -139,7 +139,7 @@ class GovspeakAttachmentsInlineTest < Minitest::Test
         file_extension: "txt",
         file_size: 2048,
         number_of_pages: 2,
-      )]
+      )],
     )
     link = %{<a href="#{Regexp.quote('http://a.b/test.txt')}">My Attached Text File</a>}
     type = %{<span class="type">Plain text</span>}
@@ -153,8 +153,8 @@ class GovspeakAttachmentsInlineTest < Minitest::Test
       "[embed:attachments:inline:1fe8] and [embed:attachments:inline:2abc]",
       [
         build_attachment(content_id: "1fe8", url: "http://a.b/test.txt", title: "Text File"),
-        build_attachment(content_id: "2abc", url: "http://a.b/test.pdf", title: "PDF File")
-      ]
+        build_attachment(content_id: "2abc", url: "http://a.b/test.pdf", title: "PDF File"),
+      ],
     )
     assert_match(%r{<a href="http://a.b/test.txt">Text File</a>}, rendered)
     assert_match(%r{<a href="http://a.b/test.pdf">PDF File</a>}, rendered)

--- a/test/govspeak_button_test.rb
+++ b/test/govspeak_button_test.rb
@@ -1,9 +1,9 @@
 # encoding: UTF-8
 
-require 'test_helper'
-require 'govspeak_test_helper'
+require "test_helper"
+require "govspeak_test_helper"
 
-require 'ostruct'
+require "ostruct"
 
 class GovspeakTest < Minitest::Test
   include GovspeakTestHelper
@@ -42,7 +42,7 @@ class GovspeakTest < Minitest::Test
 
   # Test that nothing renders when not given a link
   test_given_govspeak "{button}I shouldn't render a button{/button}" do
-    assert_html_output '<p>{button}I shouldn’t render a button{/button}</p>'
+    assert_html_output "<p>{button}I shouldn’t render a button{/button}</p>"
   end
 
   test_given_govspeak "Text before the button with line breaks \n\n\n{button}[Start Now](http://www.gov.uk){/button}\n\n\n test after the button" do

--- a/test/govspeak_contacts_test.rb
+++ b/test/govspeak_contacts_test.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
 
-require 'test_helper'
+require "test_helper"
 
 class GovspeakContactsTest < Minitest::Test
   def build_contact(attrs = {})
@@ -19,8 +19,8 @@ class GovspeakContactsTest < Minitest::Test
               region: "London",
               postal_code: "WC2B 6NH",
               world_location: "United Kingdom",
-            }
-          ]
+            },
+          ],
         ),
         email_addresses: attrs.fetch(
           :email_addresses,
@@ -28,8 +28,8 @@ class GovspeakContactsTest < Minitest::Test
             {
               title: "",
               email: "people@digital.cabinet-office.gov.uk",
-            }
-          ]
+            },
+          ],
         ),
         phone_numbers: attrs.fetch(
           :phone_numbers,
@@ -37,23 +37,23 @@ class GovspeakContactsTest < Minitest::Test
             {
               title: "helpdesk",
               number: "+4412345 67890",
-            }
-          ]
+            },
+          ],
         ),
         contact_form_links: attrs.fetch(
           :contact_form_links,
           [
             {
-              link: "https://www.gov.uk/contact"
-            }
-          ]
-        )
-      }
+              link: "https://www.gov.uk/contact",
+            },
+          ],
+        ),
+      },
     }
   end
 
   def compress_html(html)
-    html.gsub(/[\n\r]+[\s]*/, '')
+    html.gsub(/[\n\r]+[\s]*/, "")
   end
 
   test "contact is rendered when present in options[:contacts]" do
@@ -136,7 +136,7 @@ class GovspeakContactsTest < Minitest::Test
       {
         street_address: "125 Kingsway",
         country_name: "United Kingdom",
-      }
+      },
     ])
     govspeak = "[Contact:4f3383e4-48a2-4461-a41d-f85ea8b89ba0]"
     rendered = Govspeak::Document.new(govspeak, contacts: [contact]).to_html
@@ -152,7 +152,7 @@ class GovspeakContactsTest < Minitest::Test
     contact = build_contact(post_addresses: [
       {
         street_address: "",
-      }
+      },
     ])
     govspeak = "[Contact:4f3383e4-48a2-4461-a41d-f85ea8b89ba0]"
     rendered = Govspeak::Document.new(govspeak, contacts: [contact]).to_html
@@ -163,7 +163,7 @@ class GovspeakContactsTest < Minitest::Test
     contact = build_contact(email_addresses: [
       {
         email: "",
-      }
+      },
     ])
     govspeak = "[Contact:4f3383e4-48a2-4461-a41d-f85ea8b89ba0]"
     rendered = Govspeak::Document.new(govspeak, contacts: [contact]).to_html
@@ -174,7 +174,7 @@ class GovspeakContactsTest < Minitest::Test
     contact = build_contact(contact_form_links: [
       {
         link: "",
-      }
+      },
     ])
     govspeak = "[Contact:4f3383e4-48a2-4461-a41d-f85ea8b89ba0]"
     rendered = Govspeak::Document.new(govspeak, contacts: [contact]).to_html
@@ -185,7 +185,7 @@ class GovspeakContactsTest < Minitest::Test
     contact = build_contact(phone_numbers: [
       {
         number: "",
-      }
+      },
     ])
     govspeak = "[Contact:4f3383e4-48a2-4461-a41d-f85ea8b89ba0]"
     rendered = Govspeak::Document.new(govspeak, contacts: [contact]).to_html

--- a/test/govspeak_extract_contact_content_ids_test.rb
+++ b/test/govspeak_extract_contact_content_ids_test.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
 
-require 'test_helper'
+require "test_helper"
 
 class GovspeakExtractContactContentIdsTest < Minitest::Test
   test "contact content ids can be extracted from govspeak" do

--- a/test/govspeak_images_bang_test.rb
+++ b/test/govspeak_images_bang_test.rb
@@ -1,7 +1,7 @@
 # encoding: UTF-8
 
-require 'test_helper'
-require 'govspeak_test_helper'
+require "test_helper"
+require "govspeak_test_helper"
 
 class GovspeakImagesBangTest < Minitest::Test
   include GovspeakTestHelper
@@ -22,7 +22,7 @@ class GovspeakImagesBangTest < Minitest::Test
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>} +
-        %{</figure>}
+        %{</figure>},
       )
     end
   end
@@ -32,7 +32,7 @@ class GovspeakImagesBangTest < Minitest::Test
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt '&amp;&quot;&lt;&gt;"></div>} +
-        %{</figure>}
+        %{</figure>},
       )
     end
   end
@@ -48,49 +48,49 @@ class GovspeakImagesBangTest < Minitest::Test
   end
 
   test "!!n syntax adds image caption if given" do
-    given_govspeak "!!1", images: [Image.new(caption: 'My Caption & so on')] do
+    given_govspeak "!!1", images: [Image.new(caption: "My Caption & so on")] do
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>\n} +
         %{<figcaption><p>My Caption &amp; so on</p></figcaption>} +
-        %{</figure>}
+        %{</figure>},
       )
     end
   end
 
   test "!!n syntax ignores a blank caption" do
-    given_govspeak "!!1", images: [Image.new(caption: '  ')] do
+    given_govspeak "!!1", images: [Image.new(caption: "  ")] do
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>} +
-        %{</figure>}
+        %{</figure>},
       )
     end
   end
 
   test "¡¡n syntax adds image credit if given" do
-    given_govspeak "!!1", images: [Image.new(credit: 'My Credit & so on')] do
+    given_govspeak "!!1", images: [Image.new(credit: "My Credit & so on")] do
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>\n} +
         %{<figcaption><p>Image credit: My Credit &amp; so on</p></figcaption>} +
-        %{</figure>}
+        %{</figure>},
       )
     end
   end
 
   test "!!n syntax ignores a blank credit" do
-    given_govspeak "!!1", images: [Image.new(credit: '  ')] do
+    given_govspeak "!!1", images: [Image.new(credit: "  ")] do
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>} +
-        %{</figure>}
+        %{</figure>},
       )
     end
   end
 
   test "!!n syntax adds image caption and credit if given" do
-    given_govspeak "!!1", images: [Image.new(caption: 'My Caption & so on', credit: 'My Credit & so on')] do
+    given_govspeak "!!1", images: [Image.new(caption: "My Caption & so on", credit: "My Credit & so on")] do
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>\n} +
@@ -98,7 +98,7 @@ class GovspeakImagesBangTest < Minitest::Test
           %{<p>My Caption &amp; so on</p>\n} +
           %{<p>Image credit: My Credit &amp; so on</p>} +
         %{</figcaption>} +
-        %{</figure>}
+        %{</figure>},
       )
     end
   end

--- a/test/govspeak_images_test.rb
+++ b/test/govspeak_images_test.rb
@@ -1,7 +1,7 @@
 # encoding: UTF-8
 
-require 'test_helper'
-require 'govspeak_test_helper'
+require "test_helper"
+require "govspeak_test_helper"
 
 class GovspeakImagesTest < Minitest::Test
   include GovspeakTestHelper
@@ -18,7 +18,7 @@ class GovspeakImagesTest < Minitest::Test
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>} +
-        %{</figure>}
+        %{</figure>},
       )
     end
   end
@@ -28,7 +28,7 @@ class GovspeakImagesTest < Minitest::Test
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt '&amp;&quot;&lt;&gt;"></div>} +
-        %{</figure>}
+        %{</figure>},
       )
     end
   end
@@ -39,49 +39,49 @@ class GovspeakImagesTest < Minitest::Test
   end
 
   test "Image:image-id syntax adds image caption if given" do
-    given_govspeak "[Image:image-id]", images: [build_image(caption: 'My Caption & so on')] do
+    given_govspeak "[Image:image-id]", images: [build_image(caption: "My Caption & so on")] do
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>\n} +
         %{<figcaption><p>My Caption &amp; so on</p></figcaption>} +
-        %{</figure>}
+        %{</figure>},
       )
     end
   end
 
   test "Image:image-id syntax ignores a blank caption" do
-    given_govspeak "[Image:image-id]", images: [build_image(caption: '  ')] do
+    given_govspeak "[Image:image-id]", images: [build_image(caption: "  ")] do
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>} +
-        %{</figure>}
+        %{</figure>},
       )
     end
   end
 
   test "Image:image-id syntax adds image credit if given" do
-    given_govspeak "[Image:image-id]", images: [build_image(credit: 'My Credit & so on')] do
+    given_govspeak "[Image:image-id]", images: [build_image(credit: "My Credit & so on")] do
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>\n} +
         %{<figcaption><p>Image credit: My Credit &amp; so on</p></figcaption>} +
-        %{</figure>}
+        %{</figure>},
       )
     end
   end
 
   test "Image:image-id syntax ignores a blank credit" do
-    given_govspeak "[Image:image-id]", images: [build_image(credit: '  ')] do
+    given_govspeak "[Image:image-id]", images: [build_image(credit: "  ")] do
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>} +
-        %{</figure>}
+        %{</figure>},
       )
     end
   end
 
   test "Image:image-id syntax adds image caption and credit if given" do
-    given_govspeak "[Image:image-id]", images: [build_image(caption: 'My Caption & so on', credit: 'My Credit & so on')] do
+    given_govspeak "[Image:image-id]", images: [build_image(caption: "My Caption & so on", credit: "My Credit & so on")] do
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>\n} +
@@ -89,7 +89,7 @@ class GovspeakImagesTest < Minitest::Test
           %{<p>My Caption &amp; so on</p>\n} +
           %{<p>Image credit: My Credit &amp; so on</p>} +
         %{</figcaption>} +
-        %{</figure>}
+        %{</figure>},
       )
     end
   end
@@ -103,7 +103,7 @@ class GovspeakImagesTest < Minitest::Test
       assert_html_output(
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>} +
-        %{</figure>}
+        %{</figure>},
       )
     end
 
@@ -112,7 +112,7 @@ class GovspeakImagesTest < Minitest::Test
         %{<figure class="image embedded">} +
         %{<div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div>} +
         %{</figure>\n} +
-        %{<p>some text</p>}
+        %{<p>some text</p>},
       )
     end
   end

--- a/test/govspeak_link_test.rb
+++ b/test/govspeak_link_test.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
 
-require 'test_helper'
+require "test_helper"
 
 class GovspeakLinkTest < Minitest::Test
   test "embedded link with link provided" do

--- a/test/govspeak_structured_headers_test.rb
+++ b/test/govspeak_structured_headers_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class GovspeakStructuredHeadersTest < Minitest::Test
   def document_body
@@ -90,7 +90,7 @@ class GovspeakStructuredHeadersTest < Minitest::Test
               text: "Sub sub heading 2.2.1",
               level: 4,
               id: "sub-sub-heading-221",
-              headers: []
+              headers: [],
             },
           ],
         },

--- a/test/govspeak_table_with_headers_test.rb
+++ b/test/govspeak_table_with_headers_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class GovspeakTableWithHeadersTest < Minitest::Test
   def expected_outcome

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -1,9 +1,9 @@
 # encoding: UTF-8
 
-require 'test_helper'
-require 'govspeak_test_helper'
+require "test_helper"
+require "govspeak_test_helper"
 
-require 'ostruct'
+require "ostruct"
 
 class GovspeakTest < Minitest::Test
   include GovspeakTestHelper
@@ -20,7 +20,7 @@ class GovspeakTest < Minitest::Test
 
   test "strips forbidden unicode characters" do
     rendered = Govspeak::Document.new(
-      "this is text with forbidden characters \u0008\u000b\ufffe\u{2ffff}\u{5fffe}"
+      "this is text with forbidden characters \u0008\u000b\ufffe\u{2ffff}\u{5fffe}",
     ).to_html
     assert_equal "<p>this is text with forbidden characters</p>\n", rendered
   end
@@ -44,17 +44,17 @@ class GovspeakTest < Minitest::Test
 ## Medium title
 }
     assert_equal [
-      Govspeak::Header.new('Big title', 1, 'big-title'),
-      Govspeak::Header.new('Small subtitle', 3, 'small-subtitle'),
-      Govspeak::Header.new('Medium title', 2, 'medium-title')
+      Govspeak::Header.new("Big title", 1, "big-title"),
+      Govspeak::Header.new("Small subtitle", 3, "small-subtitle"),
+      Govspeak::Header.new("Medium title", 2, "medium-title"),
     ], document.headers
   end
 
   test "extracts different ids for duplicate headers" do
     document = Govspeak::Document.new("## Duplicate header\n\n## Duplicate header")
     assert_equal [
-      Govspeak::Header.new('Duplicate header', 2, 'duplicate-header'),
-      Govspeak::Header.new('Duplicate header', 2, 'duplicate-header-1')
+      Govspeak::Header.new("Duplicate header", 2, "duplicate-header"),
+      Govspeak::Header.new("Duplicate header", 2, "duplicate-header-1"),
     ], document.headers
   end
 
@@ -76,10 +76,10 @@ class GovspeakTest < Minitest::Test
 </div>
 }
     assert_equal [
-      Govspeak::Header.new('First title', 1, 'first-title'),
-      Govspeak::Header.new('Nested subtitle', 2, 'nested-subtitle'),
-      Govspeak::Header.new('Double nested subtitle', 3, 'double-nested-subtitle'),
-      Govspeak::Header.new('Second double subtitle', 3, 'second-double-subtitle')
+      Govspeak::Header.new("First title", 1, "first-title"),
+      Govspeak::Header.new("Nested subtitle", 2, "nested-subtitle"),
+      Govspeak::Header.new("Double nested subtitle", 3, "double-nested-subtitle"),
+      Govspeak::Header.new("Second double subtitle", 3, "second-double-subtitle"),
     ], document.headers
   end
 
@@ -90,8 +90,8 @@ class GovspeakTest < Minitest::Test
 ## Second title {#special}
 }
     assert_equal [
-      Govspeak::Header.new('First title', 1, 'first-title'),
-      Govspeak::Header.new('Second title', 2, 'special'),
+      Govspeak::Header.new("First title", 1, "first-title"),
+      Govspeak::Header.new("Second title", 2, "special"),
     ], document.headers
   end
 
@@ -360,7 +360,7 @@ Teston
   # TODO: review whether we should require closing symbols for these extensions
   #       need to check all existing content.
   test_given_govspeak "xaa" do
-    assert_html_output '<p>xaa</p>'
+    assert_html_output "<p>xaa</p>"
     assert_text_output "xaa"
   end
 
@@ -639,12 +639,12 @@ Teston
       }
   end
 
-  test 'sanitize source input by default' do
+  test "sanitize source input by default" do
     document = Govspeak::Document.new("<script>doBadThings();</script>")
     assert_equal "", document.to_html.strip
   end
 
-  test 'it can have sanitizing disabled' do
+  test "it can have sanitizing disabled" do
     document = Govspeak::Document.new("<script>doGoodThings();</script>", sanitize: false)
     assert_equal "<script>doGoodThings();</script>", document.to_html.strip
   end

--- a/test/html_sanitizer_test.rb
+++ b/test/html_sanitizer_test.rb
@@ -31,7 +31,7 @@ class HtmlSanitizerTest < Minitest::Test
     html = "<a href='#' data-module='cross-domain-tracking' data-tracking-code='UA-XXXXXX-Y' data-tracking-name='govspeakButtonTracker'></a>"
     assert_equal(
       "<a href=\"#\" data-module=\"cross-domain-tracking\" data-tracking-code=\"UA-XXXXXX-Y\" data-tracking-name=\"govspeakButtonTracker\"></a>",
-      Govspeak::HtmlSanitizer.new(html).sanitize
+      Govspeak::HtmlSanitizer.new(html).sanitize,
     )
   end
 
@@ -40,19 +40,19 @@ class HtmlSanitizerTest < Minitest::Test
 
     assert_equal(
       "<a href=\"/\" data-module=\"track-click\" data-ecommerce-path=\"/\" data-track-category=\"linkClicked\">Test Link</a>",
-      Govspeak::HtmlSanitizer.new(html).sanitize
+      Govspeak::HtmlSanitizer.new(html).sanitize,
     )
   end
 
   test "allows images on whitelisted domains" do
     html = "<img src='http://allowed.com/image.jgp'>"
-    sanitized_html = Govspeak::HtmlSanitizer.new(html, allowed_image_hosts: ['allowed.com']).sanitize
+    sanitized_html = Govspeak::HtmlSanitizer.new(html, allowed_image_hosts: ["allowed.com"]).sanitize
     assert_equal "<img src=\"http://allowed.com/image.jgp\">", sanitized_html
   end
 
   test "removes images not on whitelisted domains" do
     html = "<img src='http://evil.com/image.jgp'>"
-    assert_equal "", Govspeak::HtmlSanitizer.new(html, allowed_image_hosts: ['allowed.com']).sanitize
+    assert_equal "", Govspeak::HtmlSanitizer.new(html, allowed_image_hosts: ["allowed.com"]).sanitize
   end
 
   test "allows table cells and table headings without a style attribute" do
@@ -62,12 +62,12 @@ class HtmlSanitizerTest < Minitest::Test
 
   test "strips table cells and headings that appear outside a table" do
     html = "<th>thing</th></tr><tr><td>thing</td>"
-    assert_equal 'thingthing', Govspeak::HtmlSanitizer.new(html).sanitize
+    assert_equal "thingthing", Govspeak::HtmlSanitizer.new(html).sanitize
   end
 
   test "normalizes table tags to inject missing rows and bodies like a browser does" do
     html = "<table><th>thing</th><td>thing</td></table>"
-    assert_equal '<table><tbody><tr><th>thing</th><td>thing</td></tr></tbody></table>', Govspeak::HtmlSanitizer.new(html).sanitize
+    assert_equal "<table><tbody><tr><th>thing</th><td>thing</td></tr></tbody></table>", Govspeak::HtmlSanitizer.new(html).sanitize
   end
 
 
@@ -82,10 +82,10 @@ class HtmlSanitizerTest < Minitest::Test
       "text-align: middle",
       "text-align: left; width: 10px",
       "background-image: url(javascript:alert('XSS'))",
-      "expression(alert('XSS'));"
+      "expression(alert('XSS'));",
     ].each do |style|
       html = "<table><thead><tr><th style=\"#{style}\">thing</th></tr></thead><tbody><tr><td style=\"#{style}\">thing</td></tr></tbody></table>"
-      assert_equal '<table><thead><tr><th>thing</th></tr></thead><tbody><tr><td>thing</td></tr></tbody></table>', Govspeak::HtmlSanitizer.new(html).sanitize
+      assert_equal "<table><thead><tr><th>thing</th></tr></thead><tbody><tr><td>thing</td></tr></tbody></table>", Govspeak::HtmlSanitizer.new(html).sanitize
     end
   end
 end

--- a/test/html_validator_test.rb
+++ b/test/html_validator_test.rb
@@ -51,7 +51,7 @@ class HtmlValidatorTest < Minitest::Test
       $P
       ",
       ":england:content goes here:england:",
-      ":scotland:content goes here:scotland:"
+      ":scotland:content goes here:scotland:",
     ]
     values.each do |value|
       assert Govspeak::HtmlValidator.new(value).valid?
@@ -88,7 +88,7 @@ class HtmlValidatorTest < Minitest::Test
 
   test "optionally disallow images not on a whitelisted domain" do
     html = "<img src='http://evil.com/image.jgp'>"
-    assert Govspeak::HtmlValidator.new(html, allowed_image_hosts: ['allowed.com']).invalid?
+    assert Govspeak::HtmlValidator.new(html, allowed_image_hosts: ["allowed.com"]).invalid?
   end
 
   test "allow <div> and <span> HTML elements" do

--- a/test/presenters/h_card_presenter_test.rb
+++ b/test/presenters/h_card_presenter_test.rb
@@ -1,93 +1,93 @@
 # encoding: utf-8
 
-require 'test_helper'
-require 'ostruct'
+require "test_helper"
+require "ostruct"
 
 class HCardPresenterTest < Minitest::Test
   def unindent(html)
-    html.gsub(/^\s+/, '')
+    html.gsub(/^\s+/, "")
   end
 
   test "renders address in UK format" do
-    assert_equal unindent(gb_addr), HCardPresenter.new(addr_fields, 'GB').render
+    assert_equal unindent(gb_addr), HCardPresenter.new(addr_fields, "GB").render
   end
 
   test "renders address in Spanish format" do
-    assert_equal unindent(es_addr), HCardPresenter.new(addr_fields, 'ES').render
+    assert_equal unindent(es_addr), HCardPresenter.new(addr_fields, "ES").render
   end
 
   test "renders address in Japanese format" do
-    assert_equal unindent(jp_addr), HCardPresenter.new(addr_fields, 'JP').render
+    assert_equal unindent(jp_addr), HCardPresenter.new(addr_fields, "JP").render
   end
 
   test "doesn't clobber address formats" do
-    gb_format_before = HCardPresenter.address_formats['gb'].dup
-    HCardPresenter.new(addr_fields, 'GB').render
+    gb_format_before = HCardPresenter.address_formats["gb"].dup
+    HCardPresenter.new(addr_fields, "GB").render
 
-    assert_equal unindent(gb_format_before), HCardPresenter.address_formats['gb']
+    assert_equal unindent(gb_format_before), HCardPresenter.address_formats["gb"]
   end
 
   test "blank properties do not render extra line breaks" do
     fields_without_region = addr_fields
-    fields_without_region.delete('region')
+    fields_without_region.delete("region")
 
-    assert_equal unindent(addr_without_region), HCardPresenter.new(fields_without_region, 'GB').render
+    assert_equal unindent(addr_without_region), HCardPresenter.new(fields_without_region, "GB").render
   end
 
   test "doesn't render a property when it's a blank string" do
     fields = addr_fields
 
-    fields['region'] = ''
-    assert_equal unindent(addr_without_region), HCardPresenter.new(fields, 'GB').render
+    fields["region"] = ""
+    assert_equal unindent(addr_without_region), HCardPresenter.new(fields, "GB").render
 
-    fields['region'] = '   '
-    assert_equal unindent(addr_without_region), HCardPresenter.new(fields, 'GB').render
+    fields["region"] = "   "
+    assert_equal unindent(addr_without_region), HCardPresenter.new(fields, "GB").render
   end
 
-  test 'uses html escaping on property values' do
+  test "uses html escaping on property values" do
     fields = addr_fields
 
-    fields['region'] = 'UK & Channel Islands'
-    assert_includes HCardPresenter.new(fields, 'GB').render, "UK &amp; Channel Islands"
+    fields["region"] = "UK & Channel Islands"
+    assert_includes HCardPresenter.new(fields, "GB").render, "UK &amp; Channel Islands"
   end
 
   test "it defaults to UK format" do
-    assert_equal unindent(gb_addr), HCardPresenter.new(addr_fields, 'FUBAR').render
+    assert_equal unindent(gb_addr), HCardPresenter.new(addr_fields, "FUBAR").render
   end
 
   test "it builds from a Contact" do
-    contact = OpenStruct.new(recipient: 'Recipient',
-                             street_address: 'Street',
-                             locality: 'Locality',
-                             region: 'Region',
-                             postal_code: 'Postcode',
-                             country_name: 'Country',
-                             country_code: 'ES')
+    contact = OpenStruct.new(recipient: "Recipient",
+                             street_address: "Street",
+                             locality: "Locality",
+                             region: "Region",
+                             postal_code: "Postcode",
+                             country_name: "Country",
+                             country_code: "ES")
     hcard = HCardPresenter.from_contact(contact)
 
     assert_equal unindent(es_addr), hcard.render
   end
 
   test "it leaves out the country name when building a GB contact" do
-    contact = OpenStruct.new(recipient: 'Recipient',
-                             street_address: 'Street',
-                             locality: 'Locality',
-                             region: 'Region',
-                             postal_code: 'Postcode',
-                             country_name: 'Country',
-                             country_code: 'GB')
+    contact = OpenStruct.new(recipient: "Recipient",
+                             street_address: "Street",
+                             locality: "Locality",
+                             region: "Region",
+                             postal_code: "Postcode",
+                             country_name: "Country",
+                             country_code: "GB")
     hcard = HCardPresenter.from_contact(contact)
 
     assert_equal unindent(addr_without_country), hcard.render
   end
 
   def addr_fields
-    { 'fn' => 'Recipient',
-      'street-address' => 'Street',
-      'postal-code' => 'Postcode',
-      'locality' => 'Locality',
-      'region' => 'Region',
-      'country-name' => 'Country' }
+    { "fn" => "Recipient",
+      "street-address" => "Street",
+      "postal-code" => "Postcode",
+      "locality" => "Locality",
+      "region" => "Region",
+      "country-name" => "Country" }
   end
 
   def gb_addr

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,20 +1,20 @@
-require 'simplecov'
-require 'simplecov-rcov'
+require "simplecov"
+require "simplecov-rcov"
 
 SimpleCov.start
 SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
 
 $:.unshift(File.expand_path("../lib")) unless $:.include?(File.expand_path("../lib"))
 
-require 'bundler'
+require "bundler"
 Bundler.setup :default, :development, :test
 
-require 'minitest/autorun'
+require "minitest/autorun"
 
 class Minitest::Test
   class << self
     def test(name, &block)
-      clean_name = name.gsub(/\s+/, '_')
+      clean_name = name.gsub(/\s+/, "_")
       method = "test_#{clean_name.gsub(/\s+/, '_')}".to_sym
       already_defined = instance_method(method) rescue false
       raise "#{method} exists" if already_defined
@@ -24,4 +24,4 @@ class Minitest::Test
   end
 end
 
-require 'govspeak'
+require "govspeak"


### PR DESCRIPTION
Govuk-lint is now deprecated and should be replaced. This does that and fixes the linting errors that were introduced. 

I don't have the best oversight on what rubocop-govuk is meant to be checking for and have had to disable quite a few cops to get it to this stage. Please pay particular attention to https://github.com/alphagov/govspeak/blob/b2d4fb32f10fb1f4b4aeb964963fce15cc997511/.rubocop.yml when reviewing as this will have the most contentious changes. 