### PR TITLE
Modify version number for actionview

### DIFF
--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -30,7 +30,7 @@ library for use in the UK Government Single Domain project'
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.require_paths = %w[lib]
 
-  s.add_dependency "actionview", "~> 5.0"
+  s.add_dependency "actionview", ">= 5.0", "< 7"
   s.add_dependency "addressable", ">= 2.3.8", "< 3"
   s.add_dependency "govuk_publishing_components", ">= 16.16"
   s.add_dependency "htmlentities", "~> 4"


### PR DESCRIPTION
This is part of some work to upgrade content publisher to rails 6.

Trello - https://trello.com/c/g9LIshqc/1158-upgrade-content-publisher-to-rails-6

In order for content publisher to be upgraded it needs to use a higher version of actionview than govspeak would allow. This allows versions 5 and 6 of actionview which should mean that we can continue upgrading content publisher and other apps that will require this.