### PR TITLE
Add rule to allow data attributes on divs

### DIFF
--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -55,6 +55,7 @@ class Govspeak::HtmlSanitizer
       attributes: {
         :all => Sanitize::Config::RELAXED[:attributes][:all] + %w[role aria-label],
         "a"  => Sanitize::Config::RELAXED[:attributes]["a"] + [:data],
+        "div" => [:data],
         "th"  => Sanitize::Config::RELAXED[:attributes]["th"] + %w[style],
         "td"  => Sanitize::Config::RELAXED[:attributes]["td"] + %w[style],
         "govspeak-embed-attachment" => %w[content-id],

--- a/test/html_sanitizer_test.rb
+++ b/test/html_sanitizer_test.rb
@@ -44,6 +44,15 @@ class HtmlSanitizerTest < Minitest::Test
     )
   end
 
+  test "allow data attributes on divs" do
+    html = "<div data-module='toggle' data-ecommerce-path='/' data-track-category='someDiv'>Test Div</div>"
+
+    assert_equal(
+      "<div data-module=\"toggle\" data-ecommerce-path=\"/\" data-track-category=\"someDiv\">Test Div</div>",
+      Govspeak::HtmlSanitizer.new(html).sanitize,
+    )
+  end
+
   test "allows images on whitelisted domains" do
     html = "<img src='http://allowed.com/image.jgp'>"
     sanitized_html = Govspeak::HtmlSanitizer.new(html, allowed_image_hosts: ["allowed.com"]).sanitize


### PR DESCRIPTION
Whitehall uses data attributes on divs to provide accessibility links.