### PR TITLE
Update version of rubocop-govuk

### DIFF
--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -44,7 +44,7 @@ library for use in the UK Government Single Domain project'
   s.add_development_dependency "minitest", "~> 5.8.3"
   s.add_development_dependency "pry-byebug"
   s.add_development_dependency "rake", "~> 0.9.0"
-  s.add_development_dependency "rubocop-govuk", "~> 1"
+  s.add_development_dependency "rubocop-govuk", "~> 2"
   s.add_development_dependency "simplecov"
   s.add_development_dependency "simplecov-rcov"
 end

--- a/lib/kramdown/parser/govuk.rb
+++ b/lib/kramdown/parser/govuk.rb
@@ -35,11 +35,11 @@ module Kramdown
             unless host.nil? || @document_domains.compact.include?(host)
               element.attr["rel"] = "external"
             end
-          # rubocop:disable Lint/HandleExceptions
+          # rubocop:disable Lint/SuppressedException
           rescue Addressable::URI::InvalidURIError
             # it's safe to ignore these very *specific* exceptions
           end
-          # rubocop:enable Lint/HandleExceptions
+          # rubocop:enable Lint/SuppressedException
         end
         super
       end


### PR DESCRIPTION
Updating the version of `rubocop-govuk` to v2 to provide dependency stability for RuboCop. 