### PR TITLE
Customise footnote markup for accessibility 

### DIFF
--- a/lib/govspeak/post_processor.rb
+++ b/lib/govspeak/post_processor.rb
@@ -120,6 +120,16 @@ module Govspeak
       end
     end
 
+    extension("use custom footnotes") do |document|
+      document.css("a.footnote").map do |el|
+        footnote_number = el[:href].gsub(/\D/, "")
+        el.content = "[footnote #{footnote_number}]"
+      end
+      document.css("[role='doc-backlink']").map do |el|
+        el.content = "[go to where this is referenced]"
+      end
+    end
+
     attr_reader :input, :govspeak_document
 
     def initialize(html, govspeak_document)

--- a/test/govspeak_footnote_test.rb
+++ b/test/govspeak_footnote_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+require "govspeak_test_helper"
+
+class GovspeakFootnoteTest < Minitest::Test
+  include GovspeakTestHelper
+
+  test_given_govspeak "
+    Footnotes can be added[^1].
+
+    [^1]: And then later defined.
+
+    Footnotes can be added too[^2].
+
+    [^2]: And then later defined too." do
+    assert_html_output '
+      <p>Footnotes can be added<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote">[footnote 1]</a></sup>.</p>
+
+      <p>Footnotes can be added too<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote">[footnote 2]</a></sup>.</p>
+
+      <div class="footnotes" role="doc-endnotes">
+        <ol>
+          <li id="fn:1" role="doc-endnote">
+            <p>And then later defined. <a href="#fnref:1" class="reversefootnote" role="doc-backlink">[go to where this is referenced]</a></p>
+          </li>
+          <li id="fn:2" role="doc-endnote">
+            <p>And then later defined too. <a href="#fnref:2" class="reversefootnote" role="doc-backlink">[go to where this is referenced]</a></p>
+          </li>
+        </ol>
+      </div>'
+  end
+end


### PR DESCRIPTION
The default footnote "backlink" only has an arrow as content. 
Screen readers only say "right arrow curving left" when they get to this element.
This is a problem in terms as accessibility as it is unclear to the users what those links do. A better solution is to use text to indicate what the link does, which is what this is aiming to achieve.

This commit changes the footnote markers from being just numbers to **footnote 1,2,3...i**. Similarly, it replaces the "back link" which is not very helpful to the user, with **"Go to where this is referenced"**, which describes precisely what the link should do.

-----

Example of a page where footnotes are being used abundantly: https://www.gov.uk/government/publications/budget-2016-documents/budget-2016

-----

### Backlink before
<img width="723" alt="Screenshot 2020-10-26 at 19 21 30" src="https://user-images.githubusercontent.com/7116819/97218360-80fa9e80-17c0-11eb-9038-a391f69b74cf.png">

### Backlink after

<img width="728" alt="Screenshot 2020-10-28 at 17 22 30" src="https://user-images.githubusercontent.com/7116819/97472845-30ab4a00-1942-11eb-86eb-f88671edf1b1.png">



### Footnote before
<img width="706" alt="Screenshot 2020-10-26 at 19 22 48" src="https://user-images.githubusercontent.com/7116819/97218590-cb7c1b00-17c0-11eb-9877-1a4c96452cf4.png">

### Footnote after

<img width="737" alt="Screenshot 2020-10-28 at 17 23 32" src="https://user-images.githubusercontent.com/7116819/97472989-589aad80-1942-11eb-8845-9aa890545b7d.png">





https://trello.com/c/SJyttlVo/459-footnotes-footnote-links-and-backlinks-unclear
