### PR TITLE
Bump to 6.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.5.7
+
+* Update GOV.UK Publishing components to version to 23.0.0 or greater
+
 ## 6.5.6
 
 * Update Kramdown version to 2.3.0 or greater

--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -30,7 +30,7 @@ library for use in the UK Government Single Domain project'
 
   s.add_dependency "actionview", ">= 5.0", "< 7"
   s.add_dependency "addressable", ">= 2.3.8", "< 3"
-  s.add_dependency "govuk_publishing_components", ">= 21.4", "< 24.0"
+  s.add_dependency "govuk_publishing_components", "~> 23.0.0"
   s.add_dependency "htmlentities", "~> 4"
   s.add_dependency "i18n", "~> 0.7"
   s.add_dependency "kramdown", ">= 2.3.0"

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "6.5.6".freeze
+  VERSION = "6.5.7".freeze
 end


### PR DESCRIPTION
Bumps gem to next version so latest publishing components are available.
Also switches the syntax of the gem call (originally updated by dependabot) to match that used across other apps.