### PR TITLE
Remove reference to advisory callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ creates an example box
 
 ## Highlights
 
-### Advisory
+### Advisory (DEPRECATED: marked for removal. Use 'Information callouts' instead.)
 
     @This is a very important message or warning@
 
@@ -77,7 +77,7 @@ highlights the enclosed text in yellow
 </h3>
 ```
 
-### Answer
+### Answer (DEPRECATED: marked for removal)
 
     {::highlight-answer}
     The VAT rate is *20%*


### PR DESCRIPTION
We haven't recommend the use of advisory 'highlights' for a long time – this readme might be the only place they're still referenced. They also have an issue with colour constrast.
Also removed the 'answer' highlight. We don't use those on mainstream anymore.