### PR TITLE
Bump version to 6.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.5.8
+
+* Customise footnote markup for accessibility (PR#192)
+
 ## 6.5.7
 
 * Update GOV.UK Publishing components to version to 23.0.0 or greater

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "6.5.7".freeze
+  VERSION = "6.5.8".freeze
 end


### PR DESCRIPTION
I just merged #192, therefore updating govspeak version to reflect this. 