### PR TITLE
Adjust footnote markup to accommodate multiple references

### DIFF
--- a/lib/govspeak/post_processor.rb
+++ b/lib/govspeak/post_processor.rb
@@ -126,7 +126,8 @@ module Govspeak
         el.content = "[footnote #{footnote_number}]"
       end
       document.css("[role='doc-backlink']").map do |el|
-        el.content = "[go to where this is referenced]"
+        backlink_number = " " + el.css("sup")[0].content if el.css("sup")[0].present?
+        el["aria-label"] = "go to where this is referenced#{backlink_number}"
       end
     end
 

--- a/test/govspeak_footnote_test.rb
+++ b/test/govspeak_footnote_test.rb
@@ -11,21 +11,36 @@ class GovspeakFootnoteTest < Minitest::Test
 
     Footnotes can be added too[^2].
 
-    [^2]: And then later defined too." do
-    assert_html_output '
+    [^2]: And then later defined too.
+
+    This footnote has a reference number[^3].
+
+    And this footnote has the same reference number[^3].
+
+    [^3]: And then they both point here." do
+    assert_html_output(
+      %(
       <p>Footnotes can be added<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote">[footnote 1]</a></sup>.</p>
 
       <p>Footnotes can be added too<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote">[footnote 2]</a></sup>.</p>
 
+      <p>This footnote has a reference number<sup id="fnref:3" role="doc-noteref"><a href="#fn:3" class="footnote">[footnote 3]</a></sup>.</p>
+
+      <p>And this footnote has the same reference number<sup id="fnref:3:1" role="doc-noteref"><a href="#fn:3" class="footnote">[footnote 3]</a></sup>.</p>
+
       <div class="footnotes" role="doc-endnotes">
         <ol>
           <li id="fn:1" role="doc-endnote">
-            <p>And then later defined. <a href="#fnref:1" class="reversefootnote" role="doc-backlink">[go to where this is referenced]</a></p>
+            <p>And then later defined. <a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
           </li>
           <li id="fn:2" role="doc-endnote">
-            <p>And then later defined too. <a href="#fnref:2" class="reversefootnote" role="doc-backlink">[go to where this is referenced]</a></p>
+            <p>And then later defined too. <a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
+          <li id="fn:3" role="doc-endnote">
+            <p>And then they both point here. <a href="#fnref:3" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a> <a href="#fnref:3:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced 2">↩<sup>2</sup></a></p>
           </li>
         </ol>
-      </div>'
+      </div>),
+    )
   end
 end


### PR DESCRIPTION
This is a follow up on the original work done for footnote accessibility here #192 

# The Problem
The original PR had replaced the footnote arrow "back link" with the words "go to where this is referenced"  like so:

<img width="726" alt="Screenshot 2020-11-05 at 18 13 03" src="https://user-images.githubusercontent.com/7116819/98279973-94f98980-1f92-11eb-9c33-b3e8b9f801cf.png">

This was done with the aim of making those links clearer to both sighted and non-sighted users.


However as we were testing the original PR, we discovered an edge case where the solution that was implemented does not work.
The edge case appears when footnotes are referenced multiple times in the body of the publication, and therefore contain multiple numbered "back links", as can be seen [here](https://www.gov.uk/government/publications/spring-budget-2017-overview-of-tax-legislation-and-rates-ootlar/annex-a-rates-and-allowances#fn:13 ).

### Multiple numbered back arrow links
<img width="717" alt="Screenshot 2020-11-05 at 18 31 43" src="https://user-images.githubusercontent.com/7116819/98281861-3eda1580-1f95-11eb-8f2c-f268a8d7f667.png">


With the changes introduced in #192, a footnote that is referenced multiple times would look like this, which is obviously an issue: 

<img width="745" alt="Screenshot 2020-11-05 at 18 17 47" src="https://user-images.githubusercontent.com/7116819/98280418-48627e00-1f93-11eb-912a-0e1c81e81b7a.png">





# The Solution 
Publishers should ideally not be using footnotes as they are not great on the web.
In the meanwhile, we're implementing a middle ground solution. This reverts the footnote "back link" to using the arrow, with the adjustment that the back link will have an `aria-label` of **"go to where this is referenced"** or **"go to where this is referenced 2,3,4... i"** when there's more than one reference. This should help AT users navigate this area, while keeping it fairly terse and understandable for sighted users. 


https://trello.com/c/SJyttlVo