### PR TITLE
Optimistic govuk_publishing_components and I18n gem versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.5.10
+
+* Be optimistic in versions of govuk_publishing_components and i18n allowed (PR#200)
+
 ## 6.5.9
 
 * Adjust footnote markup to accommodate multiple references (PR#198)

--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -39,7 +39,7 @@ library for use in the UK Government Single Domain project'
   s.add_dependency "rinku", "~> 2.0"
   s.add_dependency "sanitize", ">= 5.2.1", "< 6"
 
-  s.add_development_dependency "minitest", "~> 5.14.1"
+  s.add_development_dependency "minitest", "~> 5.14"
   s.add_development_dependency "pry-byebug"
   s.add_development_dependency "rake"
   s.add_development_dependency "rubocop-govuk", "~> 3.17.1"

--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -32,7 +32,7 @@ library for use in the UK Government Single Domain project'
   s.add_dependency "addressable", ">= 2.3.8", "< 3"
   s.add_dependency "govuk_publishing_components", ">= 23"
   s.add_dependency "htmlentities", "~> 4"
-  s.add_dependency "i18n", "~> 0.7"
+  s.add_dependency "i18n", ">= 0.7"
   s.add_dependency "kramdown", ">= 2.3.0"
   s.add_dependency "nokogiri", "~> 1.5"
   s.add_dependency "nokogumbo", "~> 2"

--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -30,7 +30,7 @@ library for use in the UK Government Single Domain project'
 
   s.add_dependency "actionview", ">= 5.0", "< 7"
   s.add_dependency "addressable", ">= 2.3.8", "< 3"
-  s.add_dependency "govuk_publishing_components", ">= 23.0", "< 23.4"
+  s.add_dependency "govuk_publishing_components", ">= 23"
   s.add_dependency "htmlentities", "~> 4"
   s.add_dependency "i18n", "~> 0.7"
   s.add_dependency "kramdown", ">= 2.3.0"

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "6.5.9".freeze
+  VERSION = "6.5.10".freeze
 end


### PR DESCRIPTION
This changes the versioning approach we use in the gemspec for govuk_publishing_components and i18n gems. I've taken an optimistic approach where we assume future versions will work until a problem is found rather than the existing pessimistic approach where we are not allowing future versions until we've tested them.

I've done this so that we don't need to re-release this gem each time new versions of govuk_publishing_components is released as this is done very frequently (sometimes 3 minor versions in a day 😱 ). I expect it's an incredibly rare event that we manage to update govuk_publishing_components in a way that breaks this gem (typically for breaking component changes we identify them before releasing).

The I18n gem has a rather stable API and the current pin was tying this to a rather old version.