### PR TITLE
Fix issue rendering $CTA followed by $C block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.5.11
+
+* Fix issue rendering $CTA blocks before $C (PR#202)
+
 ## 6.5.10
 
 * Be optimistic in versions of govuk_publishing_components and i18n allowed (PR#200)

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -272,6 +272,10 @@ module Govspeak
       lines.join
     end
 
+    # More specific tags must be defined first. Those defined earlier have a
+    # higher precedence for being matched. For example $CTA must be defined
+    # before $C otherwise the first ($C)TA fill be matched to a contact tag.
+    wrap_with_div("call-to-action", "$CTA", Govspeak::Document)
     wrap_with_div("summary", "$!")
     wrap_with_div("form-download", "$D")
     wrap_with_div("contact", "$C")
@@ -279,7 +283,6 @@ module Govspeak
     wrap_with_div("information", "$I", Govspeak::Document)
     wrap_with_div("additional-information", "$AI")
     wrap_with_div("example", "$E", Govspeak::Document)
-    wrap_with_div("call-to-action", "$CTA", Govspeak::Document)
 
     extension("address", surrounded_by("$A")) do |body|
       %(\n<div class="address"><div class="adr org fn"><p>\n#{body.sub("\n", '').gsub("\n", '<br />')}\n</p></div></div>\n)

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "6.5.10".freeze
+  VERSION = "6.5.11".freeze
 end

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -441,6 +441,25 @@ Teston
   end
 
   test_given_govspeak "
+    $CTA
+    Click here to start the tool
+    $CTA
+
+    $C
+    Here is some text
+    $C
+    " do
+    assert_html_output %(
+      <div class="call-to-action">
+      <p>Click here to start the tool</p>
+      </div>
+
+      <div class="contact">
+      <p>Here is some text</p>
+      </div>)
+  end
+
+  test_given_govspeak "
     [internal link](http://www.not-external.com)
 
     $CTA


### PR DESCRIPTION
There was a issue were the $C in the first $CTA tag was being matched with the final $C tag. This cause the block of content to be rendered as a contact instead of a call to action. This changes the priority of the regexs evaluated so $CTA tags identified and parsed before $C preventing the mis-match.