### PR TITLE
Allow optional elements to skip sanitisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.6.0
+
+* Allow passed elements to be relaxed from sanitization [#203](https://github.com/alphagov/govspeak/pull/203)
+
 ## 6.5.11
 
 * Fix issue rendering $CTA blocks before $C (PR#202)

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -53,6 +53,7 @@ module Govspeak
       @source = source ? source.dup : ""
 
       @images = options.delete(:images) || []
+      @allowed_elements = options.delete(:allowed_elements) || []
       @attachments = Array.wrap(options.delete(:attachments))
       @links = Array.wrap(options.delete(:links))
       @contacts = Array.wrap(options.delete(:contacts))
@@ -66,7 +67,7 @@ module Govspeak
     def to_html
       @to_html ||= begin
                      html = if @options[:sanitize]
-                              HtmlSanitizer.new(kramdown_doc.to_html).sanitize
+                              HtmlSanitizer.new(kramdown_doc.to_html).sanitize(allowed_elements: @allowed_elements)
                             else
                               kramdown_doc.to_html
                             end

--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -40,18 +40,19 @@ class Govspeak::HtmlSanitizer
     @allowed_image_hosts = options[:allowed_image_hosts]
   end
 
-  def sanitize
+  def sanitize(allowed_elements: [])
     transformers = [TableCellTextAlignWhitelister.new]
     if @allowed_image_hosts && @allowed_image_hosts.any?
       transformers << ImageSourceWhitelister.new(@allowed_image_hosts)
     end
-    Sanitize.clean(@dirty_html, Sanitize::Config.merge(sanitize_config, transformers: transformers))
+
+    Sanitize.clean(@dirty_html, Sanitize::Config.merge(sanitize_config(allowed_elements: allowed_elements), transformers: transformers))
   end
 
-  def sanitize_config
+  def sanitize_config(allowed_elements: [])
     Sanitize::Config.merge(
       Sanitize::Config::RELAXED,
-      elements: Sanitize::Config::RELAXED[:elements] + %w[govspeak-embed-attachment govspeak-embed-attachment-link svg path],
+      elements: Sanitize::Config::RELAXED[:elements] + %w[govspeak-embed-attachment govspeak-embed-attachment-link svg path].concat(allowed_elements),
       attributes: {
         :all => Sanitize::Config::RELAXED[:attributes][:all] + %w[role aria-label],
         "a" => Sanitize::Config::RELAXED[:attributes]["a"] + [:data],

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "6.5.11".freeze
+  VERSION = "6.6.0".freeze
 end

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -666,6 +666,11 @@ Teston
     assert_equal "<script>doGoodThings();</script>", document.to_html.strip
   end
 
+  test "it can exclude stipulated elements from sanitization" do
+    document = Govspeak::Document.new("<uncommon-element>some content</uncommon-element>", allowed_elements: %w[uncommon-element])
+    assert_equal "<uncommon-element>some content</uncommon-element>", document.to_html.strip
+  end
+
   test "identifies a Govspeak document containing malicious HTML as invalid" do
     document = Govspeak::Document.new("<script>doBadThings();</script>")
     refute document.valid?

--- a/test/html_sanitizer_test.rb
+++ b/test/html_sanitizer_test.rb
@@ -96,4 +96,10 @@ class HtmlSanitizerTest < Minitest::Test
       assert_equal "<table><thead><tr><th>thing</th></tr></thead><tbody><tr><td>thing</td></tr></tbody></table>", Govspeak::HtmlSanitizer.new(html).sanitize
     end
   end
+
+  test "excludes specified elements from sanitization" do
+    html = "<custom-allowed-element><p>text</p></custom-allowed-element>"
+    assert_equal "<p>text</p>", Govspeak::HtmlSanitizer.new(html).sanitize
+    assert_equal html, Govspeak::HtmlSanitizer.new(html).sanitize(allowed_elements: %w[custom-allowed-element])
+  end
 end


### PR DESCRIPTION
This change allows an optional array of `relaxed_sanitization_elements` to be passed to a new Document, and these will be excluded from HTML sanitization.

There is a use-case where Whitehall is submitting a `<details>` element which is being stripped by sanitization.

[Trello](https://trello.com/c/uQpgMD83/2289-5-accessible-format-request-show-hide-not-working-on-detailed-guide-pages)