### PR TITLE
Update heading & docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,8 +598,8 @@ will output
 ```html
 <div id="contact_123" class="contact">
   <div class="content">
-    <h3>Government Digital Service</h3>
     <div class="vcard contact-inner">
+      <p>Government Digital Service</p>
       <div class="email-url-number">
         <p class="email">
           <span class="type">Email</span>

--- a/lib/templates/contact.html.erb
+++ b/lib/templates/contact.html.erb
@@ -4,8 +4,8 @@
 %>
 <div id="contact_<%= contact.content_id %>" class="<%= ['contact', extra_class].flatten.join(' ') %>">
   <div class="content">
-    <h3><%= contact.title %></h3>
     <div class="vcard contact-inner">
+    <p><%= contact.title %></p>
     <% contact.post_addresses.each do |address| %>
       <%= Govspeak::HCardPresenter.new(address).render %>
     <% end %>

--- a/test/govspeak_contacts_test.rb
+++ b/test/govspeak_contacts_test.rb
@@ -62,8 +62,8 @@ class GovspeakContactsTest < Minitest::Test
     expected_html_output = %(
       <div id="contact_4f3383e4-48a2-4461-a41d-f85ea8b89ba0" class="contact postal-address">
         <div class="content">
-          <h3>Government Digital Service</h3>
           <div class="vcard contact-inner">
+            <p>Government Digital Service</p>
             <p class="adr">
               <span class="street-address">125 Kingsway</span><br>
               <span class="locality">Holborn</span><br>
@@ -106,8 +106,8 @@ class GovspeakContactsTest < Minitest::Test
     expected_html_output = %(
       <div id="contact_4f3383e4-48a2-4461-a41d-f85ea8b89ba0" class="contact">
         <div class="content">
-          <h3>Government Digital Service</h3>
           <div class="vcard contact-inner">
+            <p>Government Digital Service</p>
             <div class="email-url-number">
               <p class="email">
                 <span class="type">Email</span>


### PR DESCRIPTION
## What?

Update `govspeak` contact information to remove bold

## Why?

Contact information should not be in bold. This is confusing as it looks like a heading but is not  [(WCAG 1.3.1)](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html).  Also at present it is a `h3` which wasn't always accurate in terms of a `h2` always being before it in the context of the page

## Visual Changes
Before (left) After (right)
![image](https://user-images.githubusercontent.com/71266765/107218857-1d5f4e80-6a08-11eb-99cc-d339854bff56.png)

## Anything else?

`govspeak` is used by the gem [there is a dependant PR here.](https://github.com/alphagov/govuk_publishing_components/pull/1909)