### PR TITLE
Update to link telephone numbers

### DIFF
--- a/lib/templates/contact.html.erb
+++ b/lib/templates/contact.html.erb
@@ -26,7 +26,7 @@
       <% contact.phone_numbers.each do |number| %>
         <p class="tel">
           <span class="type"><%= number[:title] %></span>
-          <%= number[:number] %>
+          <a href="tel:<%= number[:number] %>"><%= number[:number] %></a>
         </p>
       <% end %>
       </div>


### PR DESCRIPTION
## What?

Update so telephone numbers are clickable for users. 

## Why?

While working on [this PR](https://github.com/alphagov/govuk_publishing_components/pull/1909) I thought this would improve the UX and potentially the a11y for users.

This update allows a user to click a telephone number and have the relevant app responsible for calling activated.

Automatic format detection exists for many mobile device browsers, this will convert mobile numbers into clickable numbers automatically. On desktop there are other behaviours.  At present a user will have to copy-paste or write down a number in order to call whilst viewing on desktop. 

There are different behaviours on desktop: on macOS this might result in FaceTime Audio or tethering being activated. On Windows this might activate VoIP (eg Skype), on Chromebook there are other behaviours.

## Anything else?

- [Noticed there is further conversations about this happening here](https://github.com/alphagov/govspeak/issues/101)
 
- Draft PR for comments / technical reference
- This would need investigation with users / a support matrix of behaviours
- There are other considerations and testing required (eg international numbers)
- [The Design System currently notes _not_ to do this, however acknowledges further research needed to validate](https://design-system.service.gov.uk/patterns/telephone-numbers/)

Further reading ([Link 1](https://css-tricks.com/the-current-state-of-telephone-links/), [Link 2](https://developers.google.com/web/fundamentals/native-hardware/click-to-call))

---

## Related issues and PRs

https://github.com/alphagov/govuk-design-system/issues/2022

https://github.com/alphagov/govuk-design-system/pull/2070

