### PR TITLE
Fix failing output expectation

### DIFF
--- a/test/govspeak_footnote_test.rb
+++ b/test/govspeak_footnote_test.rb
@@ -20,13 +20,13 @@ class GovspeakFootnoteTest < Minitest::Test
     [^3]: And then they both point here." do
     assert_html_output(
       %(
-      <p>Footnotes can be added<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote">[footnote 1]</a></sup>.</p>
+      <p>Footnotes can be added<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup>.</p>
 
-      <p>Footnotes can be added too<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote">[footnote 2]</a></sup>.</p>
+      <p>Footnotes can be added too<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup>.</p>
 
-      <p>This footnote has a reference number<sup id="fnref:3" role="doc-noteref"><a href="#fn:3" class="footnote">[footnote 3]</a></sup>.</p>
+      <p>This footnote has a reference number<sup id="fnref:3" role="doc-noteref"><a href="#fn:3" class="footnote" rel="footnote">[footnote 3]</a></sup>.</p>
 
-      <p>And this footnote has the same reference number<sup id="fnref:3:1" role="doc-noteref"><a href="#fn:3" class="footnote">[footnote 3]</a></sup>.</p>
+      <p>And this footnote has the same reference number<sup id="fnref:3:1" role="doc-noteref"><a href="#fn:3" class="footnote" rel="footnote">[footnote 3]</a></sup>.</p>
 
       <div class="footnotes" role="doc-endnotes">
         <ol>


### PR DESCRIPTION
## What
Tests were failing against the expected footnote markup which now contains "rel='footnote'". This was caused by a Kramdown update: https://kramdown.gettalong.org/news.html

## Why
Fixing this will get the tests passing and the build working again

