### PR TITLE
Semantics fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Update failing test [212](https://github.com/alphagov/govspeak/pull/212)
+* Fix stats headline HTML semantics [213](https://github.com/alphagov/govspeak/pull/213)
+
 ## 6.7.0
 
 * Update heading & docs [#206](https://github.com/alphagov/govspeak/pull/206)

--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ Statistic headlines highlight important numbers in content. Displays a statistic
 Creates the following:
 
 ```html
-<aside class="stat-headline">
+<div class="stat-headline">
   <p><em>13.8bn</em> years since the big bang</p>
-</aside>
+</div>
 ```
 
 ## Points of Contact

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -185,8 +185,8 @@ module Govspeak
     end
 
     extension("stat-headline", %r${stat-headline}(.*?){/stat-headline}$m) do |body|
-      %(\n\n<aside class="stat-headline">
-#{Govspeak::Document.new(body.strip).to_html}</aside>\n)
+      %(\n\n<div class="stat-headline">
+#{Govspeak::Document.new(body.strip).to_html}</div>\n)
     end
 
     # FIXME: these surrounded_by arguments look dodgy

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -30,7 +30,7 @@ class GovspeakTest < Minitest::Test
 
   test "stat-headline block extension" do
     rendered = Govspeak::Document.new("this \n{stat-headline}*13.8bn* Age of the universe in years{/stat-headline}").to_html
-    assert_equal %(<p>this</p>\n\n<aside class="stat-headline">\n<p><em>13.8bn</em> Age of the universe in years</p>\n</aside>\n), rendered
+    assert_equal %(<p>this</p>\n\n<div class="stat-headline">\n<p><em>13.8bn</em> Age of the universe in years</p>\n</div>\n), rendered
   end
 
   test "extracts headers with text, level and generated id" do


### PR DESCRIPTION
## What
The places where this appears mean it is not appropriate for it to be marked up as an "aside". This switches it to a div, improving the semantics on pages where it appears. All styling and so forth is based on the class so the element change will have no visible effect.
https://trello.com/c/rRruBvQN/706-govspeaks-statistic-headlines-use-wrong-semantics
