### PR TITLE
Fix footnotes in legislative lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * Minimum Ruby version specified at 2.6 [215](https://github.com/alphagov/govspeak/pull/215)
 
+## 6.7.2
+
+* Fix footnotes in legislative lists [216](https://github.com/alphagov/govspeak/pull/216)
+
 ## 6.7.1
 
 * Update failing test [212](https://github.com/alphagov/govspeak/pull/212)

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -140,11 +140,12 @@ module Govspeak
         list_items = footnotes.map do |footnote|
           number = footnote[0]
           text = footnote[1].strip
+          footnote_definition = Govspeak::Document.new(text).to_html[/(?<=<p>).*(?=<\/p>)/]
 
           <<~HTML_SNIPPET
             <li id="fn:#{number}" role="doc-endnote">
               <p>
-                #{text}<a href="#fnref:#{number}" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
+                #{footnote_definition}<a href="#fnref:#{number}" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
               </p>
             </li>
           HTML_SNIPPET

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "6.7.1".freeze
+  VERSION = "6.7.2".freeze
 end

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -725,6 +725,42 @@ Teston
   end
 
   test_given_govspeak "
+    $LegislativeList
+    * 1. Item 1[^1] with a [link](http://www.gov.uk)
+    * 2. Item 2
+    * 3. Item 3[^2]
+    $EndLegislativeList
+
+    [^1]: Footnote definition one with a [link](http://www.gov.uk) included
+    [^2]: Footnote definition two with an external [link](http://www.google.com)
+  " do
+    assert_html_output %(
+      <ol class="legislative-list">
+        <li>1. Item 1<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup> with a <a href="http://www.gov.uk">link</a>
+      </li>
+        <li>2. Item 2</li>
+        <li>3. Item 3<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup>
+      </li>
+      </ol>
+
+      <div class="footnotes" role="doc-endnotes">
+        <ol>
+          <li id="fn:1" role="doc-endnote">
+        <p>
+          Footnote definition one with a <a href="http://www.gov.uk">link</a> included<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
+        </p>
+      </li>
+      <li id="fn:2" role="doc-endnote">
+        <p>
+          Footnote definition two with an external <a rel="external" href="http://www.google.com">link</a><a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
+        </p>
+      </li>
+        </ol>
+      </div>
+    )
+  end
+
+  test_given_govspeak "
     The quick brown
     $LegislativeList
     * 1. fox jumps over

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -761,6 +761,44 @@ Teston
   end
 
   test_given_govspeak "
+    $LegislativeList
+    * 1. Item 1[^1] with an ACRONYM
+    * 2. Item 2[^2]
+    * 3. Item 3
+    $EndLegislativeList
+
+    [^1]: Footnote definition one
+    [^2]: Footnote definition two with an ACRONYM
+
+    *[ACRONYM]: This is the acronym explanation
+  " do
+    assert_html_output %(
+      <ol class="legislative-list">
+        <li>1. Item 1<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup> with an <abbr title="This is the acronym explanation">ACRONYM</abbr>
+      </li>
+        <li>2. Item 2<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup>
+      </li>
+        <li>3. Item 3</li>
+      </ol>
+
+      <div class="footnotes" role="doc-endnotes">
+        <ol>
+          <li id="fn:1" role="doc-endnote">
+        <p>
+          Footnote definition one<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
+        </p>
+      </li>
+      <li id="fn:2" role="doc-endnote">
+        <p>
+          Footnote definition two with an <abbr title="This is the acronym explanation">ACRONYM</abbr><a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
+        </p>
+      </li>
+        </ol>
+      </div>
+    )
+  end
+
+  test_given_govspeak "
     The quick brown
     $LegislativeList
     * 1. fox jumps over

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -592,6 +592,139 @@ Teston
   end
 
   test_given_govspeak "
+    $LegislativeList
+    * 1. Item 1[^1]
+    * 2. Item 2[^2]
+    * 3. Item 3
+    $EndLegislativeList
+
+    [^1]: Footnote definition one
+    [^2]: Footnote definition two
+  " do
+    assert_html_output %(
+      <ol class="legislative-list">
+        <li>1. Item 1<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup>
+      </li>
+        <li>2. Item 2<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup>
+      </li>
+        <li>3. Item 3</li>
+      </ol>
+
+      <div class="footnotes" role="doc-endnotes">
+        <ol>
+          <li id="fn:1" role="doc-endnote">
+        <p>
+          Footnote definition one<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
+        </p>
+      </li>
+      <li id="fn:2" role="doc-endnote">
+        <p>
+          Footnote definition two<a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
+        </p>
+      </li>
+        </ol>
+      </div>
+    )
+  end
+
+  test_given_govspeak "
+    $LegislativeList
+    * 1. Item 1[^1]
+    * 2. Item 2
+    * 3. Item 3
+    $EndLegislativeList
+
+    This is a paragraph with a footnote[^2].
+
+    $LegislativeList
+    * 1. Item 1
+    * 2. Item 2[^3]
+    * 3. Item 3
+    $EndLegislativeList
+
+    [^1]: Footnote definition one
+    [^2]: Footnote definition two
+    [^3]: Footnote definition two
+  " do
+    assert_html_output %(
+      <ol class="legislative-list">
+        <li>1. Item 1<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup>
+      </li>
+        <li>2. Item 2</li>
+        <li>3. Item 3</li>
+      </ol>
+
+      <p>This is a paragraph with a footnote<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup>.</p>
+
+      <ol class="legislative-list">
+        <li>1. Item 1</li>
+        <li>2. Item 2<sup id="fnref:3" role="doc-noteref"><a href="#fn:3" class="footnote" rel="footnote">[footnote 3]</a></sup>
+      </li>
+        <li>3. Item 3</li>
+      </ol>
+
+      <div class="footnotes" role="doc-endnotes">
+        <ol>
+          <li id="fn:1" role="doc-endnote">
+        <p>
+          Footnote definition one<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
+        </p>
+      </li>
+      <li id="fn:2" role="doc-endnote">
+        <p>
+          Footnote definition two<a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
+        </p>
+      </li>
+      <li id="fn:3" role="doc-endnote">
+        <p>
+          Footnote definition two<a href="#fnref:3" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
+        </p>
+      </li>
+        </ol>
+      </div>
+    )
+  end
+
+  test_given_govspeak "
+    $LegislativeList
+    * 1. Item 1[^1] with a [link](http://www.gov.uk)
+    * 2. Item 2
+    * 3. Item 3
+    $EndLegislativeList
+
+    This is a paragraph with a footnote[^2]
+
+    [^1]: Footnote definition one
+    [^2]: Footnote definition two
+  " do
+    assert_html_output %(
+      <ol class="legislative-list">
+        <li>1. Item 1<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup> with a <a href="http://www.gov.uk">link</a>
+      </li>
+        <li>2. Item 2</li>
+        <li>3. Item 3</li>
+      </ol>
+
+      <p>This is a paragraph with a footnote<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup></p>
+
+      <div class="footnotes" role="doc-endnotes">
+        <ol>
+          <li id="fn:1" role="doc-endnote">
+        <p>
+          Footnote definition one<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
+        </p>
+      </li>
+      <li id="fn:2" role="doc-endnote">
+        <p>
+          Footnote definition two<a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
+        </p>
+      </li>
+        </ol>
+      </div>
+    )
+  end
+
+  test_given_govspeak "
     The quick brown
     $LegislativeList
     * 1. fox jumps over


### PR DESCRIPTION
## What
This fixes an issue with footnotes within legislative lists in Whitehall.
Trello card: https://trello.com/c/yfeqz1no/2561-footnotes-dont-work-within-legislativelist-on-manuals-publisher-5

## Why
This has been a longstanding issue and is heavily used in legislation papers. 
It means that publishers cannot use footnotes within certain kinds of content, and so cannot always follow the design guidelines. Having markdown that's reliable and effective is helpful for selling our accessibility approach (avoiding PDFs) to policy colleagues.

## Visual Changes
Before (footnotes in a legislative list not converted into html):
<img width="736" alt="Screenshot 2021-09-06 at 12 39 21" src="https://user-images.githubusercontent.com/19667619/132212304-a5db9e18-2bd5-45ce-b429-e7aa8e4d01bd.png">

After (footnotes in a legislative list now showing):
<img width="699" alt="Screenshot 2021-09-06 at 12 40 29" src="https://user-images.githubusercontent.com/19667619/132212328-9021b76f-ebf0-4606-b194-c3300ffbdf84.png">

Before (footnote definitions missing):
<img width="708" alt="Screenshot 2021-09-06 at 12 44 13" src="https://user-images.githubusercontent.com/19667619/132212531-d73efcb7-cd4e-4c65-bbaa-294dd1b2401f.png">

After (footnote definitions now showing):
![Screenshot 2021-09-06 at 12 48 05](https://user-images.githubusercontent.com/19667619/132212924-21f7cdc3-e293-4751-9212-e25685763bb6.png)



