### PR TITLE
Fix footnotes to work within call-to-action boxes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.7.5
+
+* Fix footnotes in call-to-action boxes [222](https://github.com/alphagov/govspeak/pull/222)
+
 ## 6.7.4
 
 * Remove Nokogumbo dependency to [resolve warning](https://github.com/sparklemotion/nokogiri/issues/2205) [220](https://github.com/alphagov/govspeak/pull/220)

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "6.7.4".freeze
+  VERSION = "6.7.5".freeze
 end

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -474,6 +474,101 @@ Teston
   end
 
   test_given_govspeak "
+    $CTA
+    Click here to start the tool[^1]
+    $CTA
+    [^1]: Footnote definition one
+    " do
+    assert_html_output %(
+      <div class="call-to-action">
+      <p>Click here to start the tool<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup></p>
+      </div>
+      <div class="footnotes" role="doc-endnotes">
+        <ol>
+          <li id="fn:1" role="doc-endnote">
+        <p>
+          Footnote definition one<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
+        </p>
+      </li>
+        </ol>
+      </div>
+    )
+  end
+
+  test_given_govspeak "
+    $CTA
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Fusce felis ante[^1], lobortis non quam sit amet, tempus interdum justo.
+    $CTA
+    $CTA
+    Pellentesque quam enim, egestas sit amet congue sit amet[^2], ultrices vitae arcu.
+    Fringilla, metus dui scelerisque est.
+    $CTA
+    [^1]: Footnote definition one
+    [^2]: Footnote definition two
+    " do
+    assert_html_output %(
+      <div class="call-to-action">
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Fusce felis ante<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup>, lobortis non quam sit amet, tempus interdum justo.</p>
+      </div>
+
+      <div class="call-to-action">
+      <p>Pellentesque quam enim, egestas sit amet congue sit amet<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup>, ultrices vitae arcu.
+      Fringilla, metus dui scelerisque est.</p>
+      </div>
+      <div class="footnotes" role="doc-endnotes">
+        <ol>
+          <li id="fn:1" role="doc-endnote">
+        <p>
+          Footnote definition one<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
+        </p>
+      </li>
+      <li id="fn:2" role="doc-endnote">
+        <p>
+          Footnote definition two<a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
+        </p>
+      </li>
+        </ol>
+      </div>
+    )
+  end
+
+  test_given_govspeak "
+    $CTA
+    Click here to start the tool[^1]
+    $CTA
+
+    Lorem ipsum dolor sit amet[^2]
+
+    [^1]: Footnote definition 1
+    [^2]: Footnote definition 2
+    " do
+    assert_html_output %(
+      <div class="call-to-action">
+      <p>Click here to start the tool<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup></p>
+      </div>
+
+      <p>Lorem ipsum dolor sit amet<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup></p>
+
+      <div class="footnotes" role="doc-endnotes">
+        <ol>
+          <li id="fn:1" role="doc-endnote">
+        <p>
+          Footnote definition 1<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
+        </p>
+      </li>
+      <li id="fn:2" role="doc-endnote">
+        <p>
+          Footnote definition 2<a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
+        </p>
+      </li>
+        </ol>
+      </div>
+    )
+  end
+
+  test_given_govspeak "
     1. rod
     2. jane
     3. freddy" do


### PR DESCRIPTION
[Trello card](https://trello.com/c/dhYfvaXp/2727-footnotes-dont-work-within-call-to-action-boxes-5)

## What
We need to parse footnotes when they appear in $CTA call-to-action boxes. Currently they appear as markdown ([^1]).

## Why
In call to action boxes ($CTA), footnotes don't work and are just shown as markdown - [^1] - meaning for some publications where there's a need to use GOV.UK patterns to replicate some styling in a printed publication isn't possible.
