### PR TITLE
Add draggable false to button markup and validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Add draggable false to button markup and validation [#224](https://github.com/alphagov/govspeak/pull/224)
+
 ## 6.7.5
 
 * Fix footnotes in call-to-action boxes [222](https://github.com/alphagov/govspeak/pull/222)

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -224,7 +224,7 @@ module Govspeak
       text = text.strip
       href = href.strip
 
-      %(\n<a role="button" class="#{button_classes}" href="#{href}" #{data_attribute}>#{text}</a>\n)
+      %(\n<a role="button" draggable="false" class="#{button_classes}" href="#{href}" #{data_attribute}>#{text}</a>\n)
     end
 
     extension("highlight-answer") do |body|

--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -55,7 +55,7 @@ class Govspeak::HtmlSanitizer
       elements: Sanitize::Config::RELAXED[:elements] + %w[govspeak-embed-attachment govspeak-embed-attachment-link svg path].concat(allowed_elements),
       attributes: {
         :all => Sanitize::Config::RELAXED[:attributes][:all] + %w[role aria-label],
-        "a" => Sanitize::Config::RELAXED[:attributes]["a"] + [:data],
+        "a" => Sanitize::Config::RELAXED[:attributes]["a"] + [:data] + %w[draggable],
         "svg" => Sanitize::Config::RELAXED[:attributes][:all] + %w[xmlns width height viewbox focusable],
         "path" => Sanitize::Config::RELAXED[:attributes][:all] + %w[fill d],
         "div" => [:data],

--- a/test/govspeak_button_test.rb
+++ b/test/govspeak_button_test.rb
@@ -47,7 +47,7 @@ class GovspeakTest < Minitest::Test
     assert_html_output %(
       <p>Text before the button with line breaks</p>
 
-      <p><a class="gem-c-button govuk-button" role="button" href="http://www.gov.uk">Start Now</a></p>
+      <p><a class="gem-c-button govuk-button" role="button" draggable="false" href="http://www.gov.uk">Start Now</a></p>
 
       <p>test after the button</p>
     )
@@ -65,21 +65,21 @@ class GovspeakTest < Minitest::Test
   # Make sure button renders when typical linebreaks are before it, seen in publishing applications
   test_given_govspeak "{button}[Line breaks](https://gov.uk/random){/button}\r\n\r\n{button}[Continue](https://gov.uk/random){/button}\r\n\r\n{button}[Continue](https://gov.uk/random){/button}" do
     assert_html_output %(
-      <p><a class="gem-c-button govuk-button" role="button" href="https://gov.uk/random">Line breaks</a></p>
+      <p><a class="gem-c-button govuk-button" role="button" draggable="false" href="https://gov.uk/random">Line breaks</a></p>
 
-      <p><a class="gem-c-button govuk-button" role="button" href="https://gov.uk/random">Continue</a></p>
+      <p><a class="gem-c-button govuk-button" role="button" draggable="false" href="https://gov.uk/random">Continue</a></p>
 
-      <p><a class="gem-c-button govuk-button" role="button" href="https://gov.uk/random">Continue</a></p>
+      <p><a class="gem-c-button govuk-button" role="button" draggable="false" href="https://gov.uk/random">Continue</a></p>
     )
   end
 
   test_given_govspeak "{button}[More line breaks](https://gov.uk/random){/button}\n\n{button}[Continue](https://gov.uk/random){/button}\n\n{button}[Continue](https://gov.uk/random){/button}" do
     assert_html_output %(
-      <p><a class="gem-c-button govuk-button" role="button" href="https://gov.uk/random">More line breaks</a></p>
+      <p><a class="gem-c-button govuk-button" role="button" draggable="false" href="https://gov.uk/random">More line breaks</a></p>
 
-      <p><a class="gem-c-button govuk-button" role="button" href="https://gov.uk/random">Continue</a></p>
+      <p><a class="gem-c-button govuk-button" role="button" draggable="false" href="https://gov.uk/random">Continue</a></p>
 
-      <p><a class="gem-c-button govuk-button" role="button" href="https://gov.uk/random">Continue</a></p>
+      <p><a class="gem-c-button govuk-button" role="button" draggable="false" href="https://gov.uk/random">Continue</a></p>
     )
   end
 
@@ -104,7 +104,7 @@ class GovspeakTest < Minitest::Test
       <p>lorem lorem lorem
       lorem lorem lorem</p>
 
-      <p><a class="gem-c-button govuk-button" role="button" href="https://gov.uk/random">Random page</a></p>
+      <p><a class="gem-c-button govuk-button" role="button" draggable="false" href="https://gov.uk/random">Random page</a></p>
 
       <p>lorem lorem lorem
       lorem lorem lorem</p>


### PR DESCRIPTION
## What
Adds `draggable="false"` to the govspeak button extension output.

## Why
This is in response to a change to button markup in the components gem (https://github.com/alphagov/govuk_publishing_components/pull/2448) which wasn't reflected in govspeak. This caused the govspeak validator to assume all buttons failed as the in-app markup was including `draggable="false"` whilst sanitised govspeak wasn't.

[Zendesk ticket which prompted this](https://govuk.zendesk.com/agent/tickets/4779605)

No visual changes
