### PR TITLE
Bump release to 6.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 6.7.6
 
 * Add draggable false to button markup and validation [#224](https://github.com/alphagov/govspeak/pull/224)
 

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "6.7.5".freeze
+  VERSION = "6.7.6".freeze
 end


### PR DESCRIPTION
* Add draggable false to button markup and validation [#224](https://github.com/alphagov/govspeak/pull/224)