### PR TITLE
Fix broken HTML in CTA extension.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.7.7
+
+* Fix broken HTML in CTA extension. [#226](https://github.com/alphagov/govspeak/pull/226)
+
 ## 6.7.6
 
 * Add draggable false to button markup and validation [#224](https://github.com/alphagov/govspeak/pull/224)

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -322,7 +322,7 @@ module Govspeak
     end
 
     extension("call-to-action", surrounded_by("$CTA")) do |body|
-      doc = Kramdown::Document.new(body.strip).to_html
+      doc = Kramdown::Document.new(preprocess(body.strip), @options).to_html
       doc = %(\n<div class="call-to-action">\n#{doc}</div>\n)
       footnotes = body.scan(/\[\^(\d+)\]/).flatten
 

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "6.7.6".freeze
+  VERSION = "6.7.7".freeze
 end

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -442,6 +442,60 @@ Teston
 
   test_given_govspeak "
     $CTA
+
+    This is a test:
+
+    s1. This is number 1.
+    s2. This is number 2.
+    s3. This is number 3.
+    s4. This is number 4.
+
+    $CTA" do
+    assert_html_output %(
+        <div class="call-to-action">
+        <p>This is a test:</p>
+
+        <ol class="steps">
+        <li>
+        <p>This is number 1.</p>
+        </li>
+        <li>
+        <p>This is number 2.</p>
+        </li>
+        <li>
+        <p>This is number 3.</p>
+        </li>
+        <li>
+        <p>This is number 4.</p>
+        </li>
+        </ol>
+        </div>
+        )
+  end
+
+  test_given_govspeak "
+    $CTA
+    [external link](http://www.external.com) some text
+    $CTA
+    " do
+    assert_html_output %(
+      <div class="call-to-action">
+      <p><a rel="external" href="http://www.external.com">external link</a> some text</p>
+      </div>)
+  end
+
+  test_given_govspeak "
+    $CTA
+    [internal link](http://www.not-external.com) some text
+    $CTA", document_domains: %w[www.not-external.com] do
+    assert_html_output %(
+      <div class="call-to-action">
+      <p><a href="http://www.not-external.com">internal link</a> some text</p>
+      </div>)
+  end
+
+  test_given_govspeak "
+    $CTA
     Click here to start the tool
     $CTA
 


### PR DESCRIPTION
[Zendesk ticket](https://govuk.zendesk.com/agent/tickets/4792626)
[Zendesk ticket](https://govuk.zendesk.com/agent/tickets/4786050)

## What
Updated the extension and created specs to ensure the HTML is rendered as expected.

## Why
Call to Action HTML render broken for ordered list.

## Visual Changes
current:
<img width="637" alt="Screenshot 2021-12-08 at 14 17 41" src="https://user-images.githubusercontent.com/4563521/145223730-e5d1241c-3325-4b74-b215-7d9b161f357b.png">

expected: 
<img width="291" alt="Screenshot 2021-12-08 at 14 18 51" src="https://user-images.githubusercontent.com/4563521/145223945-487bddec-361b-44b9-896d-27973bb77d90.png">

