### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ Once govspeak has been updated and version incremented then:
 
 Also, consider if:
 - [whitehall](https://github.com/alphagov/whitehall) needs updating (as custom govspeak changes are present)
-- [govuk-content-schema](https://github.com/alphagov/govuk-content-schemas) needs updating
-- [govpspeak-preview](https://github.com/alphagov/govspeak-preview) is worth updating
+- [govpspeak-preview](https://github.com/alphagov/govspeak-preview) needs updating
 
 Any pages that use govspeak to generate Content will need to *republished* in order for the new changes to be reflected.  
 


### PR DESCRIPTION
## What
Update README

## Why
To reflect that govuk-content-schema does not use govspeak but it is recommended to update govpspeak-preview.

## Visual Changes
![Screenshot 2021-12-10 at 10 22 26](https://user-images.githubusercontent.com/4563521/145558542-b8c5d573-04b2-4a49-8df0-f7fe46f4336d.png)

