### PR TITLE
Update acronym alt text function to not target acronyms within HTML tags

### DIFF
--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -465,7 +465,7 @@ module Govspeak
 
     def add_acronym_alt_text(html)
       @acronyms.each do |acronym|
-        html.gsub!(acronym[0], "<abbr title=\"#{acronym[1].strip}\">#{acronym[0]}</abbr>")
+        html.gsub!(/(?<!=")#{acronym[0]}/, "<abbr title=\"#{acronym[1].strip}\">#{acronym[0]}</abbr>")
       end
     end
   end


### PR DESCRIPTION
## What
Updates the function `add_acronym_alt_text` to not target acronyms in use within html tag attributes eg:

When our acronym is `EIF`, the updated function **will** target

```html
<p>#EIF</p>
```

...but **won't** target

```html
<a href="#EIF">a link</a>
```

## Why
Details of issue and proposed solution can be found in https://govuk.zendesk.com/agent/tickets/4819383

This is not a perfect solution as it does not solve instances of acronyms with a hash suffix within a tag's attributes in locations other than right at the start of a given attribute. For example it won't catch:

```html
<a href="/my-page#EIF">a link</a>
```