### PR TITLE
Reverts acronym change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.7.8
+
+* Fixes bug which reverts acronyms from being converted into abbr tags [#229](https://github.com/alphagov/govspeak/pull/229)
+
 ## 6.7.7
 
 * Fix broken HTML in CTA extension. [#226](https://github.com/alphagov/govspeak/pull/226)

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -464,9 +464,10 @@ module Govspeak
     end
 
     def add_acronym_alt_text(html)
-      @acronyms.each do |acronym|
-        html.gsub!(acronym[0], "<abbr title=\"#{acronym[1].strip}\">#{acronym[0]}</abbr>")
-      end
+      # FIXME: this code is buggy and replaces abbreviations in HTML tags - removing the functionality for now
+      # @acronyms.each do |acronym|
+      #   html.gsub!(acronym[0], "<abbr title=\"#{acronym[1].strip}\">#{acronym[0]}</abbr>")
+      # end
     end
   end
 end

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "6.7.7".freeze
+  VERSION = "6.7.8".freeze
 end

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -1048,43 +1048,44 @@ Teston
     )
   end
 
-  test_given_govspeak "
-    $LegislativeList
-    * 1. Item 1[^1] with an ACRONYM
-    * 2. Item 2[^2]
-    * 3. Item 3
-    $EndLegislativeList
-
-    [^1]: Footnote definition one
-    [^2]: Footnote definition two with an ACRONYM
-
-    *[ACRONYM]: This is the acronym explanation
-  " do
-    assert_html_output %(
-      <ol class="legislative-list">
-        <li>1. Item 1<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup> with an <abbr title="This is the acronym explanation">ACRONYM</abbr>
-      </li>
-        <li>2. Item 2<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup>
-      </li>
-        <li>3. Item 3</li>
-      </ol>
-
-      <div class="footnotes" role="doc-endnotes">
-        <ol>
-          <li id="fn:1" role="doc-endnote">
-        <p>
-          Footnote definition one<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-      <li id="fn:2" role="doc-endnote">
-        <p>
-          Footnote definition two with an <abbr title="This is the acronym explanation">ACRONYM</abbr><a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-        </ol>
-      </div>
-    )
-  end
+  # FIXME: this code is buggy and replaces abbreviations in HTML tags - removing the functionality for now
+  # test_given_govspeak "
+  #   $LegislativeList
+  #   * 1. Item 1[^1] with an ACRONYM
+  #   * 2. Item 2[^2]
+  #   * 3. Item 3
+  #   $EndLegislativeList
+  #
+  #   [^1]: Footnote definition one
+  #   [^2]: Footnote definition two with an ACRONYM
+  #
+  #   *[ACRONYM]: This is the acronym explanation
+  # " do
+  #   assert_html_output %(
+  #     <ol class="legislative-list">
+  #       <li>1. Item 1<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup> with an <abbr title="This is the acronym explanation">ACRONYM</abbr>
+  #     </li>
+  #       <li>2. Item 2<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup>
+  #     </li>
+  #       <li>3. Item 3</li>
+  #     </ol>
+  #
+  #     <div class="footnotes" role="doc-endnotes">
+  #       <ol>
+  #         <li id="fn:1" role="doc-endnote">
+  #       <p>
+  #         Footnote definition one<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
+  #       </p>
+  #     </li>
+  #     <li id="fn:2" role="doc-endnote">
+  #       <p>
+  #         Footnote definition two with an <abbr title="This is the acronym explanation">ACRONYM</abbr><a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
+  #       </p>
+  #     </li>
+  #       </ol>
+  #     </div>
+  #   )
+  # end
 
   test_given_govspeak "
     The quick brown


### PR DESCRIPTION
This code is buggy as it replaces abbreviations in HTML tag attributes,
rather than just text tags. This has knock on consequences of removing
HTML attachments from documents in Whitehall when creating a new
edition.

This commit reverts the change for now with a view to updating the
logic in the near future.

Original commit:
https://github.com/alphagov/govspeak/pull/216/files#diff-acb6db6cd67285bd5380398c9e51ced8940ed7c4110706d038cbb243310e4055R453

Zendesk:
https://govuk.zendesk.com/agent/tickets/4819383