### PR TITLE
Use GitHub Actions for continuous integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: Continuous integration
+on: [push, pull_request]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [2.6, 2.7]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+    - run: bundle exec rake
+  
+  release:
+    needs: test
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+
+      # Update to >= v3.0.5
+      # https://gitlab.com/gitlab-org/gitlab-qa/-/issues/431
+    - run: gem update --system
+
+    - env:
+        GEM_HOST_API_KEY: ${{ secrets.ALPHAGOV_RUBYGEMS_API_KEY }}
+      run: |
+        VERSION=$(ruby -e "puts eval(File.read('govspeak.gemspec')).version")
+        GEM_VERSION=$(gem list --exact --remote govspeak)
+
+        if [ "${GEM_VERSION}" != "govspeak (${VERSION})" ]; then
+          gem build govspeak.gemspec
+          gem push "govspeak-${VERSION}.gem"
+        fi
+
+        if ! git ls-remote --tags --exit-code origin v${VERSION}; then
+          git tag v${VERSION}
+          git push --tags
+        fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,0 @@
-#!/usr/bin/env groovy
-
-library("govuk")
-
-node {
-  govuk.buildProject()
-}


### PR DESCRIPTION
## What

This PR configures the repository to use GitHub Actions for continuous integration instead of Jenkins.

It's mostly a copy & paste of the [CI configuration for `rubocop-govuk`](https://github.com/alphagov/rubocop-govuk/blob/main/.github/workflows/ci.yml) which also uses GitHub Actions to test and publish to RubyGems.

## Why

To adopt [GOV.UK RFC-123](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-123-github-actions-ci.md).

## Visual Changes

None. This is a dev workflow change, so there are no changes to the gem itself.