### PR TITLE
Fix a validation bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Fix a bug which resulted in validation errors on 'Start Button' elements [#237](https://github.com/alphagov/govspeak/pull/237)
+
 ## 6.8.0
 
 * Drop support for Ruby 2.6 which reaches End of Life (EOL) on 31/03/2022

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -54,6 +54,7 @@ module Govspeak
 
       @images = options.delete(:images) || []
       @allowed_elements = options.delete(:allowed_elements) || []
+      @allowed_image_hosts = options.delete(:allowed_image_hosts) || []
       @attachments = Array.wrap(options.delete(:attachments))
       @links = Array.wrap(options.delete(:links))
       @contacts = Array.wrap(options.delete(:contacts))
@@ -69,7 +70,8 @@ module Govspeak
     def to_html
       @to_html ||= begin
         html = if @options[:sanitize]
-                 HtmlSanitizer.new(kramdown_doc.to_html).sanitize(allowed_elements: @allowed_elements)
+                 HtmlSanitizer.new(kramdown_doc.to_html, allowed_image_hosts: @allowed_image_hosts)
+                              .sanitize(allowed_elements: @allowed_elements)
                else
                  kramdown_doc.to_html
                end

--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -46,7 +46,17 @@ class Govspeak::HtmlSanitizer
       transformers << ImageSourceWhitelister.new(@allowed_image_hosts)
     end
 
-    Sanitize.clean(@dirty_html, Sanitize::Config.merge(sanitize_config(allowed_elements: allowed_elements), transformers: transformers))
+    # It would be cleaner to move this `transformers` key into the `sanitize_config` method rather
+    # than having to use Sanitize::Config.merge() twice in succession. However, `sanitize_config`
+    # is a public method and it looks like other projects depend on it behaving the way it
+    # currently does – i.e. to return Sanitize config without any transformers.
+    # e.g. https://github.com/alphagov/hmrc-manuals-api/blob/4a83f78d0bb839520155623fd9b63b3b12a3b13a/app/validators/no_dangerous_html_in_text_fields_validator.rb#L44
+    config_with_transformers = Sanitize::Config.merge(
+      sanitize_config(allowed_elements: allowed_elements),
+      transformers: transformers,
+    )
+
+    Sanitize.clean(@dirty_html, config_with_transformers)
   end
 
   def sanitize_config(allowed_elements: [])

--- a/lib/govspeak/html_validator.rb
+++ b/lib/govspeak/html_validator.rb
@@ -1,9 +1,9 @@
 class Govspeak::HtmlValidator
   attr_reader :govspeak_string
 
-  def initialize(govspeak_string, sanitization_options = {})
+  def initialize(govspeak_string, options = {})
     @govspeak_string = govspeak_string.dup.force_encoding(Encoding::UTF_8)
-    @sanitization_options = sanitization_options
+    @allowed_image_hosts = options[:allowed_image_hosts]
   end
 
   def invalid?
@@ -24,6 +24,10 @@ private
   end
 
   def govspeak_to_html(sanitize:)
-    Govspeak::Document.new(govspeak_string, sanitize: sanitize).to_html
+    Govspeak::Document.new(
+      govspeak_string,
+      sanitize: sanitize,
+      allowed_image_hosts: @allowed_image_hosts,
+    ).to_html
   end
 end

--- a/lib/govspeak/html_validator.rb
+++ b/lib/govspeak/html_validator.rb
@@ -11,17 +11,19 @@ class Govspeak::HtmlValidator
   end
 
   def valid?
-    dirty_html = govspeak_to_html
-    clean_html = Govspeak::HtmlSanitizer.new(dirty_html, @sanitization_options).sanitize
+    dirty_html = govspeak_to_html(sanitize: false)
+    clean_html = govspeak_to_html(sanitize: true)
     normalise_html(dirty_html) == normalise_html(clean_html)
   end
+
+private
 
   # Make whitespace in html tags consistent
   def normalise_html(html)
     Nokogiri::HTML5.fragment(html).to_s
   end
 
-  def govspeak_to_html
-    Govspeak::Document.new(govspeak_string, sanitize: false).to_html
+  def govspeak_to_html(sanitize:)
+    Govspeak::Document.new(govspeak_string, sanitize: sanitize).to_html
   end
 end


### PR DESCRIPTION
## What

This PR fixes a couple of bugs in the way generated HTML markup was being sanitised and validated.

### 1. Validation before post-processing

Validation is now performed **before** [post-processors][] have acted upon the generated HTML. This means that disallowed HTML tags and attributes can now be inserted into a document by post-processors – since they are trusted code – but still cannot be inserted into the source Markdown by users.

In other words, the order of processing is now:

```
[ User input ] --> [ Validation ] --> [ Post-processing ]
```

This seems to be the most logical way for validation to be performed, although it wasn't actually being done that way in practice.

Previously, post-processing would happen **before** the validation step:

```
[ User input ] --> [ Post-processing ] --> [ Validation ]
```

Resulting in changes in post-processed elements – such as [button elements][] – to be run through the validator.

[post-processors]: https://github.com/alphagov/govspeak/blob/2940b49b3a5c508b8f9e36e63e1cdedff6468ff9/lib/govspeak/post_processor.rb
[button elements]: https://github.com/alphagov/govspeak/blob/2940b49b3a5c508b8f9e36e63e1cdedff6468ff9/lib/govspeak/post_processor.rb#L105-L121

### 2. Apply `allowed_image_hosts` consistently

The first change resulted in tests covering the `allowed_image_hosts` sanitiser option to fail.

It turns out the `allowed_image_hosts` wasn't being carried through to the `Govspeak::Document` object which performed the final HTML conversion & sanitisation, meaning this rule wasn't being applied consistently between the validation and final markup produced.

<!-- Description of the change being made -->
<!-- Remember to add this to the CHANGELOG if applicable -->

## Why is this needed?
<!-- What are the reasons behind this change being made? -->

This was brought to our attention by users of Publishing apps who have recently become unable to save documents containing [Start Button](https://design-system.service.gov.uk/components/button/#start-buttons) elements.

Whenever a document contained the following snippet of Govspeak-flavoured Markdown:

```
{button start}[Start Now](https://gov.uk/example-service){/button}
```

a validation error would be displayed, and the user's changes wouldn't save.

<img width="662" alt="Screenshot 2022-03-15 at 16 29 24" src="https://user-images.githubusercontent.com/7735945/158425761-919db65c-8502-47c3-86f8-a564160a6f8e.png">

Therefore, users have been unable to create/update any pages that happen to contain a start button.

## Why did this happen?

This bug only appeared recently, and it wasn't caused by a change in this gem.

This gem is dependent on the [govuk_publishing_components][] gem to render button elements. A [recent change][] to that gem, which tweaked the HTML markup used for buttons, had the side effect of exposing a flaw in the way validation was being performed in this gem.

The new HTML markup for buttons was triggering a validation error due to it using disallowed HTML attributes – even though this wasn't HTML entered by the user, but was instead generated by the govuk_publishing_components gem.

[govuk_publishing_components]: https://github.com/alphagov/govuk_publishing_components
[recent change]: https://github.com/alphagov/govuk_publishing_components/commit/0133558abe3547ef9f0cb2bf5f699d7c63c6d7fc

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

None.

Trello: https://trello.com/c/HQ85E1ux/1315-publishers-unable-to-save-drafts-when-there-is-a-start-button