### PR TITLE
Fix footnote numbering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.8.2
+
+* Fix footnote numbering [#239](https://github.com/alphagov/govspeak/pull/239)
+
 ## 6.8.1
 
 * Fix a bug which resulted in validation errors on 'Start Button' elements [#237](https://github.com/alphagov/govspeak/pull/237)

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -138,7 +138,7 @@ module Govspeak
     def footnote_definitions(source)
       is_legislative_list = source.scan(/\$LegislativeList.*?\[\^\d\]*.*?\$EndLegislativeList/m).size.positive?
       is_cta = source.scan(/\$CTA.*?\[\^\d\]*.*?\$CTA/m).size.positive?
-      footnotes = source.scan(/\[\^(\d+)\]:(.*)/)
+      footnotes = source.scan(/^\s*\[\^(\d+)\]:(.*)/)
       @acronyms = source.scan(/(?<=\*)\[(.*)\]:(.*)/)
       if (is_legislative_list || is_cta) && footnotes.size.positive?
         list_items = footnotes.map do |footnote|

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "6.8.1".freeze
+  VERSION = "6.8.2".freeze
 end

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -1048,6 +1048,48 @@ Teston
     )
   end
 
+  test_given_govspeak "
+    $LegislativeList
+    1.  some text[^1]:
+    $EndLegislativeList
+    [^1]: footnote text
+  " do
+    assert_html_output %(
+      <p>1.  some text<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup>:</p>
+
+      <div class="footnotes" role="doc-endnotes">
+        <ol>
+          <li id="fn:1" role="doc-endnote">
+        <p>
+          footnote text<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
+        </p>
+      </li>
+        </ol>
+      </div>
+    )
+  end
+
+  test_given_govspeak "
+    $LegislativeList
+    1.  some text[^1]: extra
+    $EndLegislativeList
+    [^1]: footnote text
+    " do
+      assert_html_output %(
+      <p>1.  some text<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup>: extra</p>
+
+      <div class="footnotes" role="doc-endnotes">
+        <ol>
+          <li id="fn:1" role="doc-endnote">
+        <p>
+          footnote text<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
+        </p>
+      </li>
+        </ol>
+      </div>
+    )
+    end
+
   # FIXME: this code is buggy and replaces abbreviations in HTML tags - removing the functionality for now
   # test_given_govspeak "
   #   $LegislativeList


### PR DESCRIPTION
## What
Fix bug with footnote numbering in a legislative list

## Why
To prevent from showing empty additional footnotes.

[Trello card](https://trello.com/c/R23P4vYE/315-investigate-and-fix-bug-with-footnote-numbering-in-a-legislative-list)
