### PR TITLE
Bump kramdown >=2.3.0 ->  >=2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.8.3
+
+* Require Kramdown minimum version of 2.3.1 to avoid CVE-2021-28834 [#246](https://github.com/alphagov/govspeak/pull/246)
+
 ## 6.8.2
 
 * Fix footnote numbering [#239](https://github.com/alphagov/govspeak/pull/239)

--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -34,7 +34,7 @@ library for use in the UK Government Single Domain project'
   s.add_dependency "govuk_publishing_components", ">= 23"
   s.add_dependency "htmlentities", "~> 4"
   s.add_dependency "i18n", ">= 0.7"
-  s.add_dependency "kramdown", ">= 2.3.0"
+  s.add_dependency "kramdown", ">= 2.3.1"
   s.add_dependency "nokogiri", "~> 1.12"
   s.add_dependency "rinku", "~> 2.0"
   s.add_dependency "sanitize", "~> 6"

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "6.8.2".freeze
+  VERSION = "6.8.3".freeze
 end


### PR DESCRIPTION
Bump kramdown by minor version to patch security issue:

https://github.com/advisories/GHSA-52p9-v744-mwjj

## What
dependency minor version bump

## Why
fixes security issue with gem dependency

## Visual Changes
n/a
