### PR TITLE
Ensure html attachments without <tbody> elements duplicate successfully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.8.4
+
+* Fix bug where inconsistent linebreaks trigger validations [#250](https://github.com/alphagov/govspeak/pull/250)
+
 ## 6.8.3
 
 * Require Kramdown minimum version of 2.3.1 to avoid CVE-2021-28834 [#246](https://github.com/alphagov/govspeak/pull/246)

--- a/lib/govspeak/html_validator.rb
+++ b/lib/govspeak/html_validator.rb
@@ -20,7 +20,7 @@ private
 
   # Make whitespace in html tags consistent
   def normalise_html(html)
-    Nokogiri::HTML5.fragment(html).to_s
+    Nokogiri::HTML5.fragment(html).to_s.gsub("\n", "")
   end
 
   def govspeak_to_html(sanitize:)

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "6.8.3".freeze
+  VERSION = "6.8.4".freeze
 end

--- a/test/html_validator_test.rb
+++ b/test/html_validator_test.rb
@@ -108,4 +108,9 @@ class HtmlValidatorTest < Minitest::Test
     assert Govspeak::HtmlValidator.new("<table><tr><td>Hello</td></tr></table>").valid?, "No <tbody> is valid"
     assert Govspeak::HtmlValidator.new("<table><tbody><tr><td>Hello</td></tr></tbody></table>").valid?, "<tbody> is valid"
   end
+
+  test "allow HTML tables with \n" do
+    html = "<table>\n<thead>\n<tr>\n<th></th>\n<th></th>\n<th colspan=\"3\"></th>\n\n</tr>\n</thead>\n<tr>\n<th></th>\n<td></td>\n<td></td>\n<td></td>\n<td></td>\n</tr>\n</table>"
+    assert Govspeak::HtmlValidator.new(html).valid?, 'Tables with no <tbody> and \n are valid'
+  end
 end


### PR DESCRIPTION
## Description

At the moment, there's a bug where some attachments are not being successfully duped when a new edition is created by the `Edition#create_draft` method. We'e received a couple (or more) Zendesk tickets regarding the issue.

After some digging it's become clear that this occurs when a user inputs questionable HMTL for tables. Specifically when they don't use a `<tbody>` for the body of the table.

When a user saves a HTML attachment on Whitehall it's validates it via the Govspeak::HtmlValidator.

This calls the Document#to_html method. When we pass `sanitize: true` into the options we then call the `Sanitize#sanitize` method from the `Sanitize` gem which uses the `fragment` method. Here's the code:

```
def fragment(html)
  return '' unless html

  frag = Nokogiri::HTML5.fragment(preprocess(html), **@config[:parser_options])
  node!(frag)
  to_html(frag)
end
```
https://github.com/rgrove/sanitize/blob/main/lib/sanitize.rb#L66-L68

The `Nokogiri::HTML5.fragment` has some cool, but slightly unexpected behaviour that is outlined here
https://makandracards.com/makandra/481802-how-to-prevent-nokogiri-from-fixing-invalid-html

Essentially though it fixes up invalid HTML. One side effect is that it can add extra linebreaks that were not there before, which is happening in this case.

By the time the HMTL is compared with and without sanitisation in the Validator, subtle whitespace changes have snuck in which causes the `==` operator to fail.

While we could definitely implement a bespoke fix for this issue, we've decided to go with removing linebreaks from the html before comparing it with and without sanitisation. It's largely just noise and could definitely cause issues down the line again when further releases occur.

## Trello card 

https://trello.com/c/HSlot63V/623-investigate-bug-html-attachments-sometimes-dont-copy-over-to-new-drafts