### PR TITLE
WIP Support 'anchor link' headings

### DIFF
--- a/lib/govspeak/post_processor.rb
+++ b/lib/govspeak/post_processor.rb
@@ -47,6 +47,19 @@ module Govspeak
       end
     end
 
+    extension("apply anchor links to headings") do |document|
+      document.css(".govuk-anchor").map do |el|
+        anchor_heading = GovukPublishingComponents.render(
+          "govuk_publishing_components/components/heading",
+          text: el.children.to_s,
+          heading_level: el.name[/[0-9]/].to_i,
+          id: el.attributes["id"].value,
+          is_anchor: true, # TBC
+        )
+        el.swap(anchor_heading)
+      end
+    end
+
     extension("embed attachment HTML") do |document|
       document.css("govspeak-embed-attachment").map do |el|
         attachment = govspeak_document.attachments.detect { |a| a[:id] == el["id"] }

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -227,6 +227,16 @@ Teston
     assert_text_output "Hello I am very helpful Young Workers"
   end
 
+  test_given_govspeak "## Hello\n{: .govuk-anchor}" do
+    assert_html_output %(
+      <h2 class="gem-c-heading gem-c-heading--font-size-27" id="hello">Hello</h2>
+      <a href="#hello">
+        <span aria-hidden="true">#</span>
+        <span class="hidden">Section titled hello</span>
+      </a>)
+    assert_text_output "Hello Section titled hello"
+  end
+
   test_given_govspeak "% I am very helpful" do
     assert_html_output %(
       <div role="note" aria-label="Warning" class="application-notice help-notice">


### PR DESCRIPTION
## What

Adds a feature to GovSpeak whereby appending `{: .govuk-anchor}` below a given heading results in the heading becoming an 'anchor link' heading.

This PR is one part of the equation; the other part will be a change to the [heading component](https://components.publishing.service.gov.uk/component-guide/heading) of [govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components).

NB it feels a bit weird to write a test here that checks the markup generated by govuk_publishing_components; it should be enough to test that a call to the `render` method is made, with the expected parameters.

Dependent on https://github.com/alphagov/govuk_publishing_components/pull/3121.

## Why
For GIFT week, we're exploring making it easier for users to share links to specific sections on GOV.UK pages, in a similar style to GitHub ([example](https://github.com/alphagov/govuk-developer-docs#before-running-the-app)).

Trello: https://trello.com/c/Gz6dirLk/36-turn-headings-into-anchor-links

## Visual Changes

TBC