### PR TITLE
Fix superscript rendering in table headings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.0.1
+
+* Govspeak was stripping superscript from markdown when it shouldn't have. [#264](https://github.com/alphagov/govspeak/pull/264)
+
 ## 7.0.0
 
 * BREAKING CHANGE Remove `PriorityList`, the `PrimaryList` JS module to render the priority list on the frontend is to be removed [#249](https://github.com/alphagov/govspeak/pull/249)

--- a/lib/govspeak/post_processor.rb
+++ b/lib/govspeak/post_processor.rb
@@ -85,20 +85,20 @@ module Govspeak
 
     extension("Add table headers and row / column scopes") do |document|
       document.css("thead th").map do |el|
-        el.content = el.content.gsub(/^# /, "")
-        el.content = el.content.gsub(/[[:space:]]/, "") if el.content.blank? # Removes a strange whitespace in the cell if the cell is already blank.
-        el.name = "td" if el.content.blank? # This prevents a `th` with nothing inside it; a `td` is preferable.
-        el[:scope] = "col" if el.content.present? # `scope` shouldn't be used if there's nothing in the table heading.
+        el.inner_html = el.inner_html.gsub(/^# /, "")
+        el.inner_html = el.inner_html.gsub(/[[:space:]]/, "") if el.inner_html.blank? # Removes a strange whitespace in the cell if the cell is already blank.
+        el.name = "td" if el.inner_html.blank? # This prevents a `th` with nothing inside it; a `td` is preferable.
+        el[:scope] = "col" if el.inner_html.present? # `scope` shouldn't be used if there's nothing in the table heading.
       end
 
       document.css(":not(thead) tr td:first-child").map do |el|
-        next unless el.content.match?(/^#($|\s.*$)/)
+        next unless el.inner_html.match?(/^#($|\s.*$)/)
 
         # Replace '# ' and '#', but not '#Word'.
         # This runs on the first child of the element to preserve any links
         el.children.first.content = el.children.first.content.gsub(/^#($|\s)/, "")
-        el.name = "th" if el.content.present? # This also prevents a `th` with nothing inside it; a `td` is preferable.
-        el[:scope] = "row" if el.content.present? # `scope` shouldn't be used if there's nothing in the table heading.
+        el.name = "th" if el.inner_html.present? # This also prevents a `th` with nothing inside it; a `td` is preferable.
+        el[:scope] = "row" if el.inner_html.present? # `scope` shouldn't be used if there's nothing in the table heading.
       end
     end
 
@@ -106,7 +106,7 @@ module Govspeak
       document.css(".govuk-button").map do |el|
         button_html = GovukPublishingComponents.render(
           "govuk_publishing_components/components/button",
-          text: el.content,
+          text: el.inner_html,
           href: el["href"],
           start: el["data-start"],
           data_attributes: {
@@ -123,7 +123,7 @@ module Govspeak
     extension("use custom footnotes") do |document|
       document.css("a.footnote").map do |el|
         footnote_number = el[:href].gsub(/\D/, "")
-        el.content = "[footnote #{footnote_number}]"
+        el.inner_html = "[footnote #{footnote_number}]"
       end
       document.css("[role='doc-backlink']").map do |el|
         backlink_number = " #{el.css('sup')[0].content}" if el.css("sup")[0].present?

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "7.0.0".freeze
+  VERSION = "7.0.1".freeze
 end

--- a/test/govspeak_table_with_headers_test.rb
+++ b/test/govspeak_table_with_headers_test.rb
@@ -131,6 +131,34 @@ class GovspeakTableWithHeadersTest < Minitest::Test
 )
   end
 
+  def expected_outcome_for_table_with_table_headers_containing_superscript
+    %(
+<table>
+  <thead>
+    <tr>
+      <th scope="col">Foo<sup>bar</sup>
+</th>
+      <th scope="col">Third Column</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Cell</td>
+      <td>Cell</td>
+    </tr>
+  </tbody>
+</table>
+)
+  end
+
+  def document_body_with_table_headers_containing_superscript
+    @document_body_with_table_headers_containing_superscript ||= Govspeak::Document.new(%(
+| Foo<sup>bar</sup>     | Third Column        |
+| ---------------       | ------------------- |
+| Cell                  | Cell                |
+))
+  end
+
   def expected_outcome_for_table_headers_containing_links
     %(
 <table>
@@ -241,5 +269,9 @@ class GovspeakTableWithHeadersTest < Minitest::Test
 
   test "Table headers are not blank" do
     assert_equal document_body_with_blank_table_headers.to_html, expected_outcome_for_table_with_blank_table_headers
+  end
+
+  test "Table header superscript should parse" do
+    assert_equal document_body_with_table_headers_containing_superscript.to_html, expected_outcome_for_table_with_table_headers_containing_superscript
   end
 end


### PR DESCRIPTION
Govspeak was stripping superscript from markdown when it shouldn't have. This was reported in Zendesk ticket: https://govuk.zendesk.com/agent/tickets/5140425

## What
Govspeak was stripping superscript from markdown when it shouldn't have. This was reported in Zendesk ticket: https://govuk.zendesk.com/agent/tickets/5140425


## Why
For full details check Zendesk ticket linked above


## Visual Changes

| Before | After |
|--------|------|
|![Screenshot 2022-12-16 at 16 23 57](https://user-images.githubusercontent.com/5111927/208143499-16c48be2-9751-4d54-a8dd-e74968756120.png)|![Screenshot 2022-12-16 at 16 24 02](https://user-images.githubusercontent.com/5111927/208143514-b50b13aa-b33a-4554-a4cc-5f0fa1271589.png)|

<details>
<summary>Code that we used</summary>
<pre>
|Provided services<sup>1</sup> | **Proportion of respondents** |
:---: | ---:
| yes<sup>1</sup> | 70% (n = 58) |
</pre>
</details>


