### PR TITLE
Fix for abbreviations nested in button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.0.2
+
+* Fix for abbreviations nested in button. [#267] (https://github.com/alphagov/govspeak/pull/267)
+
 ## 7.0.1
 
 * Govspeak was stripping superscript from markdown when it shouldn't have. [#264](https://github.com/alphagov/govspeak/pull/264)

--- a/lib/govspeak/post_processor.rb
+++ b/lib/govspeak/post_processor.rb
@@ -106,7 +106,7 @@ module Govspeak
       document.css(".govuk-button").map do |el|
         button_html = GovukPublishingComponents.render(
           "govuk_publishing_components/components/button",
-          text: el.inner_html,
+          text: el.inner_html.html_safe,
           href: el["href"],
           start: el["data-start"],
           data_attributes: {

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "7.0.1".freeze
+  VERSION = "7.0.2".freeze
 end

--- a/test/govspeak_button_test.rb
+++ b/test/govspeak_button_test.rb
@@ -110,4 +110,15 @@ class GovspeakTest < Minitest::Test
       lorem lorem lorem</p>
     )
   end
+
+  test_given_govspeak "
+    {button start}[Start now JSA](https://www.apply-for-new-style-jsa.dwp.gov.uk/?lang=cy){/button}
+    \n\n
+    *[JSA]: Jobseeker's Allowance
+  " do
+    assert_text_output "Start now JSA"
+    assert_html_output %(
+      <p><a class="gem-c-button govuk-button govuk-button--start" role="button" data-module="govuk-button" draggable="false" href="https://www.apply-for-new-style-jsa.dwp.gov.uk/?lang=cy"> Start now <abbr title="Jobseeker's Allowance">JSA</abbr><svg class="govuk-button__start-icon govuk-!-display-none-print" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewbox="0 0 33 40" focusable="false" aria-hidden="true"><path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path></svg></a></p>
+    )
+  end
 end


### PR DESCRIPTION
## What
Fix so  abbreviations nested in button are displayed properly.

## Why
[Trello card] (https://trello.com/c/kSRdRaYf/1025-5165353-govspeak-issue-apply-for-new-style-jobseekers-allowance-jsa-green-button-content-change-request-department-for-work-pens)
