### PR TITLE
Make image and attachment embedding syntax more consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.1.1
+
+* Make image and attachment embedding syntax more consistent [#274](https://github.com/alphagov/govspeak/pull/274)
+
 ## 7.1.0
 
 * Drop support for Ruby 2.7 [#272](https://github.com/alphagov/govspeak/pull/272)

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -424,7 +424,7 @@ module Govspeak
       renderer.render(contact: ContactPresenter.new(contact))
     end
 
-    extension("Image", /#{NEW_PARAGRAPH_LOOKBEHIND}\[Image:\s*(.*?)\s*\]/) do |image_id|
+    extension("Image", /^\[Image:\s*(.*?)\s*\]/) do |image_id|
       image = images.detect { |c| c.is_a?(Hash) && c[:id] == image_id }
       next "" unless image
 

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -431,7 +431,7 @@ module Govspeak
       render_image(ImagePresenter.new(image))
     end
 
-    extension("Attachment", /#{NEW_PARAGRAPH_LOOKBEHIND}\[Attachment:\s*(.*?)\s*\]/) do |attachment_id|
+    extension("Attachment", /^\[Attachment:\s*(.*?)\s*\]/) do |attachment_id|
       next "" if attachments.none? { |a| a[:id] == attachment_id }
 
       %(<govspeak-embed-attachment id="#{attachment_id}"></govspeak-embed-attachment>)

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "7.1.0".freeze
+  VERSION = "7.1.1".freeze
 end

--- a/test/govspeak_attachment_test.rb
+++ b/test/govspeak_attachment_test.rb
@@ -21,7 +21,7 @@ class GovspeakAttachmentTest < Minitest::Test
     assert_match(/Attachment Title/, rendered)
   end
 
-  test "only renders attachment when markdown extension starts on a line" do
+  test "only renders attachment when markdown extension starts on a new line" do
     attachment = {
       id: "attachment.pdf",
       url: "http://example.com/attachment.pdf",
@@ -34,5 +34,10 @@ class GovspeakAttachmentTest < Minitest::Test
     rendered = render_govspeak("[Attachment:attachment.pdf] some text", [attachment])
     assert_match(/<section class="gem-c-attachment/, rendered)
     assert_match(/<p>some text<\/p>/, rendered)
+
+    rendered = render_govspeak("some text\n[Attachment:attachment.pdf]\nsome more text", [attachment])
+    assert_match(/<p>some text<\/p>/, rendered)
+    assert_match(/<section class="gem-c-attachment/, rendered)
+    assert_match(/<p>some more text<\/p>/, rendered)
   end
 end

--- a/test/govspeak_images_bang_test.rb
+++ b/test/govspeak_images_bang_test.rb
@@ -80,4 +80,30 @@ class GovspeakImagesBangTest < Minitest::Test
       )
     end
   end
+
+  test "!!n syntax must start on a new line" do
+    given_govspeak "some text !!1", images: [Image.new] do
+      assert_html_output("<p>some text !!1</p>")
+    end
+
+    given_govspeak "!!1", images: [Image.new] do
+      assert_html_output(
+        "<figure class=\"image embedded\"><div class=\"img\"><img src=\"http://example.com/image.jpg\" alt=\"my alt\"></div></figure>",
+      )
+    end
+
+    given_govspeak "!!1 some text", images: [Image.new] do
+      assert_html_output(
+        "<figure class=\"image embedded\"><div class=\"img\"><img src=\"http://example.com/image.jpg\" alt=\"my alt\"></div></figure>\n<p>some text</p>",
+      )
+    end
+
+    given_govspeak "some text\n!!1\nsome more text", images: [Image.new] do
+      assert_html_output <<~HTML
+        <p>some text</p>
+        <figure class="image embedded"><div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div></figure>
+        <p>some more text</p>
+      HTML
+    end
+  end
 end

--- a/test/govspeak_images_test.rb
+++ b/test/govspeak_images_test.rb
@@ -88,5 +88,13 @@ class GovspeakImagesTest < Minitest::Test
         "<figure class=\"image embedded\"><div class=\"img\"><img src=\"http://example.com/image.jpg\" alt=\"my alt\"></div></figure>\n<p>some text</p>",
       )
     end
+
+    given_govspeak "some text\n[Image:image-id]\nsome more text", images: [build_image] do
+      assert_html_output <<~HTML
+        <p>some text</p>
+        <figure class="image embedded"><div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div></figure>
+        <p>some more text</p>
+      HTML
+    end
   end
 end


### PR DESCRIPTION
## What

This PR makes changes to the `[Image:]` and `[Attachment:]` embed syntaxes so they behave more consistently with the older `!!n` (image) and `!@n` (attachment) syntaxes.

In particular, `[Image:]` and `[Attachment:]` only worked when preceded by two newline characters (`\n\n`). Whereas `!!n` and `!@n` only needed to be preceded by one newline character (`\n`).

### Before

For example, this would work when embedding with the `!!n` syntax:

```
A paragraph of text.
!!1
Another paragraph of text.
```

But this **would not work** with the `[Image:]` syntax:

```
A paragraph of text.
[Image: example.jpg]
Another paragraph of text.
```

### After

Both examples above work as expected.

They both produce HTML output like:

```html
<p>A paragraph of text.</p>
<figure><!-- image is embedded here --></figure>
<p>Another paragraph of text.</p>
```

## Why

We've recently introduced [support for `[Image:]` syntax in Whitehall][1], and will soon be adding support for `[Attachment:]` too. We quickly received feedback from users that the new image embedding syntax wasn't working – and it turns out it was because they were used to embedding images using `!!n` syntax, which only needed one newline character.

To resolve the inconsistency, we've decided to bring the syntaxes in line by making the newer `[Image:]` and `[Attachment:]` syntaxes more lenient as users were expecting.

[1]: https://github.com/alphagov/whitehall/pull/7589

Trello: https://trello.com/c/FxDTL9Ic/1272-update-image-syntax-so-it-behaves-similar-to-images-added-in-whitehall-previously-no-line-break-needed