### PR TITLE
Test coverage for embedding filenames with spaces

### DIFF
--- a/test/govspeak_attachment_link_test.rb
+++ b/test/govspeak_attachment_link_test.rb
@@ -35,4 +35,15 @@ class GovspeakAttachmentLinkTest < Minitest::Test
     assert(root.css("p").size, 0)
     assert_match(/Attachment Title\s*test/, root.text)
   end
+
+  test "allows spaces and special characters in the identifier" do
+    attachment = {
+      id: "This is the name of my &%$@€? attachment",
+      url: "http://example.com/attachment.pdf",
+      title: "Attachment Title",
+    }
+
+    rendered = render_govspeak("[AttachmentLink: This is the name of my &%$@€? attachment]", [attachment])
+    assert_match(/Attachment Title/, rendered)
+  end
 end

--- a/test/govspeak_attachment_test.rb
+++ b/test/govspeak_attachment_test.rb
@@ -21,6 +21,18 @@ class GovspeakAttachmentTest < Minitest::Test
     assert_match(/Attachment Title/, rendered)
   end
 
+  test "allows spaces and special characters in the identifier" do
+    attachment = {
+      id: "This is the name of my &%$@€? attachment",
+      url: "http://example.com/attachment.pdf",
+      title: "Attachment Title",
+    }
+
+    rendered = render_govspeak("[Attachment: This is the name of my &%$@€? attachment]", [attachment])
+    assert_match(/<section class="gem-c-attachment/, rendered)
+    assert_match(/Attachment Title/, rendered)
+  end
+
   test "only renders attachment when markdown extension starts on a new line" do
     attachment = {
       id: "attachment.pdf",

--- a/test/govspeak_images_test.rb
+++ b/test/govspeak_images_test.rb
@@ -72,6 +72,15 @@ class GovspeakImagesTest < Minitest::Test
     end
   end
 
+  test "allows spaces and special characters in the identifier" do
+    image = build_image(id: "This is the name of my &%$@€? image")
+    given_govspeak "[Image: This is the name of my &%$@€? image]", images: [image] do
+      assert_html_output(
+        "<figure class=\"image embedded\"><div class=\"img\"><img src=\"http://example.com/image.jpg\" alt=\"my alt\"></div></figure>",
+      )
+    end
+  end
+
   test "Image is not inserted when it does not start on a new line" do
     given_govspeak "some text [Image:image-id]", images: [build_image] do
       assert_html_output("<p>some text [Image:image-id]</p>")


### PR DESCRIPTION
Add tests to cover embedding attachments, attachment links, and images, when the file identifier (usually the filename) contains spaces and special characters.

I've not added this to the CHANGELOG or bumped the gem version since it doesn't change functionality of the gem itself. It simply adds test cases to explicitly cover the existing behaviour and protect against future regressions.

Done while working on Trello card: https://trello.com/c/Z5IwGrAw/1177-remove-custom-attachment-rendering-from-whitehall