### PR TITLE
Wrap the text of start buttons in a span

### DIFF
--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -225,6 +225,7 @@ module Govspeak
         data_attribute << " data-tracking-name='govspeakButtonTracker'"
       end
       text = text.strip
+      text = "<span>#{text}</span>" if attributes =~ /start/
       href = href.strip
 
       %(\n<a role="button" draggable="false" class="#{button_classes}" href="#{href}" #{data_attribute}>#{text}</a>\n)

--- a/test/govspeak_button_test.rb
+++ b/test/govspeak_button_test.rb
@@ -118,7 +118,7 @@ class GovspeakTest < Minitest::Test
   " do
     assert_text_output "Start now JSA"
     assert_html_output %(
-      <p><a class="gem-c-button govuk-button govuk-button--start" role="button" data-module="govuk-button" draggable="false" href="https://www.apply-for-new-style-jsa.dwp.gov.uk/?lang=cy"> Start now <abbr title="Jobseeker's Allowance">JSA</abbr><svg class="govuk-button__start-icon govuk-!-display-none-print" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewbox="0 0 33 40" focusable="false" aria-hidden="true"><path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path></svg></a></p>
+      <p><a class="gem-c-button govuk-button govuk-button--start" role="button" data-module="govuk-button" draggable="false" href="https://www.apply-for-new-style-jsa.dwp.gov.uk/?lang=cy"><span>Start now <abbr title="Jobseeker's Allowance">JSA</abbr></span><svg class="govuk-button__start-icon govuk-!-display-none-print" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewbox="0 0 33 40" focusable="false" aria-hidden="true"><path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path></svg></a></p>
     )
   end
 end


### PR DESCRIPTION
When using an inline element (such as `<abbr>`, `<address>` or `<telephone>`) in a link with the `govuk-button--start` class applied to it, there is no spacing between the inline element and the text of the link.

The reason that this is occurring is the `display: inline-flex;` rule in the `govuk-button--start` class.

The suggested solution was to wrap the text of `start` buttons in a `<span>` tag:
https://github.com/alphagov/govuk-frontend/issues/3406#issuecomment-1563139563

This is the solution I'm implementing here.

I've done a quick test in integration, covering only a start button with an `abbr` in it.

## Before
![Screenshot 2023-06-29 at 16 32 13](https://github.com/alphagov/govspeak/assets/579522/c4930f48-4e51-4775-abd5-d993c645f31e)

## After
![Screenshot 2023-06-29 at 16 35 25](https://github.com/alphagov/govspeak/assets/579522/4bfcd25f-3bb1-43e7-9d9e-07cd38bbd2b5)

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.


