### PR TITLE
Disallow usage of style element and style attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* BREAKING: HTML style attribute and style element, which were never supposed to be available, are forbidden.
+
 ## 7.1.1
 
 * Make image and attachment embedding syntax more consistent [#274](https://github.com/alphagov/govspeak/pull/274)

--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -71,8 +71,8 @@ class Govspeak::HtmlSanitizer
         # We purposefully disable style attributes which Sanitize::Config::RELAXED allows
         :all => Sanitize::Config::RELAXED[:attributes][:all] + %w[role aria-label] - %w[style],
         "a" => Sanitize::Config::RELAXED[:attributes]["a"] + [:data] + %w[draggable],
-        "svg" => Sanitize::Config::RELAXED[:attributes][:all] + %w[xmlns width height viewbox focusable],
-        "path" => Sanitize::Config::RELAXED[:attributes][:all] + %w[fill d],
+        "svg" => %w[xmlns width height viewbox focusable],
+        "path" => %w[fill d],
         "div" => [:data],
         # The style attributes are permitted here just for the ones Kramdown for table alignment
         # we replace them in a post processor.

--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -74,8 +74,8 @@ class Govspeak::HtmlSanitizer
         "svg" => Sanitize::Config::RELAXED[:attributes][:all] + %w[xmlns width height viewbox focusable],
         "path" => Sanitize::Config::RELAXED[:attributes][:all] + %w[fill d],
         "div" => [:data],
-        # @TODO  These style attributes can be removed once we've checked there
-        # isn't hardcoded HTML in documents that uses them
+        # The style attributes are permitted here just for the ones Kramdown for table alignment
+        # we replace them in a post processor.
         "th" => Sanitize::Config::RELAXED[:attributes]["th"] + %w[style],
         "td" => Sanitize::Config::RELAXED[:attributes]["td"] + %w[style],
         "govspeak-embed-attachment" => %w[content-id],

--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -60,11 +60,16 @@ class Govspeak::HtmlSanitizer
   end
 
   def sanitize_config(allowed_elements: [])
+    # We purposefully disable style elements which Sanitize::Config::RELAXED allows
+    elements = Sanitize::Config::RELAXED[:elements] - %w[style] +
+      %w[govspeak-embed-attachment govspeak-embed-attachment-link svg path].concat(allowed_elements)
+
     Sanitize::Config.merge(
       Sanitize::Config::RELAXED,
-      elements: Sanitize::Config::RELAXED[:elements] + %w[govspeak-embed-attachment govspeak-embed-attachment-link svg path].concat(allowed_elements),
+      elements: elements,
       attributes: {
-        :all => Sanitize::Config::RELAXED[:attributes][:all] + %w[role aria-label],
+        # We purposefully disable style attributes which Sanitize::Config::RELAXED allows
+        :all => Sanitize::Config::RELAXED[:attributes][:all] + %w[role aria-label] - %w[style],
         "a" => Sanitize::Config::RELAXED[:attributes]["a"] + [:data] + %w[draggable],
         "svg" => Sanitize::Config::RELAXED[:attributes][:all] + %w[xmlns width height viewbox focusable],
         "path" => Sanitize::Config::RELAXED[:attributes][:all] + %w[fill d],

--- a/test/govspeak_tables_test.rb
+++ b/test/govspeak_tables_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class GovspeakTableWithHeadersTest < Minitest::Test
+class GovspeakTablesTest < Minitest::Test
   def expected_outcome
     %(
 <table>

--- a/test/govspeak_tables_test.rb
+++ b/test/govspeak_tables_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class GovspeakTablesTest < Minitest::Test
-  def expected_outcome
+  def expected_outcome_for_headers
     %(
 <table>
   <thead>
@@ -248,30 +248,30 @@ class GovspeakTablesTest < Minitest::Test
   end
 
   test "Cells with |# are headers" do
-    assert_equal document_body_with_hashes_for_all_headers.to_html, expected_outcome
+    assert_equal expected_outcome_for_headers, document_body_with_hashes_for_all_headers.to_html
   end
 
   test "Cells outside of thead with |# are th; thead still only contains th" do
-    assert_equal document_body_with_hashes_for_row_headers.to_html, expected_outcome
+    assert_equal expected_outcome_for_headers, document_body_with_hashes_for_row_headers.to_html
   end
 
   test "Cells are given classes to indicate alignment" do
-    assert_equal document_body_with_alignments.to_html, expected_outcome_for_table_with_alignments
+    assert_equal expected_outcome_for_table_with_alignments, document_body_with_alignments.to_html
   end
 
   test "Table headers with a scope of row are only in the first column of the table" do
-    assert_equal document_body_with_table_headers_in_the_wrong_place.to_html, expected_outcome_for_table_headers_in_the_wrong_place
+    assert_equal expected_outcome_for_table_headers_in_the_wrong_place, document_body_with_table_headers_in_the_wrong_place.to_html
   end
 
   test "Table headers with a scope of row can have embedded links" do
-    assert_equal document_body_with_table_headers_containing_links.to_html, expected_outcome_for_table_headers_containing_links
+    assert_equal expected_outcome_for_table_headers_containing_links, document_body_with_table_headers_containing_links.to_html
   end
 
   test "Table headers are not blank" do
-    assert_equal document_body_with_blank_table_headers.to_html, expected_outcome_for_table_with_blank_table_headers
+    assert_equal expected_outcome_for_table_with_blank_table_headers, document_body_with_blank_table_headers.to_html
   end
 
   test "Table header superscript should parse" do
-    assert_equal document_body_with_table_headers_containing_superscript.to_html, expected_outcome_for_table_with_table_headers_containing_superscript
+    assert_equal expected_outcome_for_table_with_table_headers_containing_superscript, document_body_with_table_headers_containing_superscript.to_html, expected_outcome_for_table_with_table_headers_containing_superscript
   end
 end

--- a/test/govspeak_tables_test.rb
+++ b/test/govspeak_tables_test.rb
@@ -259,6 +259,20 @@ class GovspeakTablesTest < Minitest::Test
     assert_equal expected_outcome_for_table_with_alignments, document_body_with_alignments.to_html
   end
 
+  test "Invalid alignment properties are dropped from cells" do
+    html = %(<table><tbody><tr><td style="text-align: middle">middle</td></tr></tbody></table>)
+    expected = "<table><tbody><tr><td>middle</td></tr></tbody></table>\n"
+
+    assert_equal expected, Govspeak::Document.new(html).to_html
+  end
+
+  test "Styles other than text-align are ignored on a table cell" do
+    html = %(<table><tbody><tr><td style="text-align: center; width: 100px;">middle</td></tr></tbody></table>)
+    expected = %(<table><tbody><tr><td class="cell-text-center">middle</td></tr></tbody></table>\n)
+
+    assert_equal expected, Govspeak::Document.new(html).to_html
+  end
+
   test "Table headers with a scope of row are only in the first column of the table" do
     assert_equal expected_outcome_for_table_headers_in_the_wrong_place, document_body_with_table_headers_in_the_wrong_place.to_html
   end

--- a/test/html_sanitizer_test.rb
+++ b/test/html_sanitizer_test.rb
@@ -89,16 +89,16 @@ class HtmlSanitizerTest < Minitest::Test
     assert_equal "<table><tbody><tr><th>thing</th><td>thing</td></tr></tbody></table>", Govspeak::HtmlSanitizer.new(html).sanitize
   end
 
-  test "allows valid text-align properties on the style attribute for table cells and table headings" do
-    %w[left right center].each do |alignment|
-      html = "<table><thead><tr><th style=\"text-align: #{alignment}\">thing</th></tr></thead><tbody><tr><td style=\"text-align: #{alignment}\">thing</td></tr></tbody></table>"
-      assert_equal html, Govspeak::HtmlSanitizer.new(html).sanitize
-    end
+  test "allows text-align properties on the style attribute for table cells and table headings" do
+    html = "<table><thead><tr><th style=\"text-align: right\">thing</th></tr></thead><tbody><tr><td style=\"text-align: center\">thing</td></tr></tbody></table>"
+    assert_equal html, Govspeak::HtmlSanitizer.new(html).sanitize
+
+    input = "<table><thead><tr><th style=\"text-align: left;width: 100px;\">thing</th></tr></thead><tbody><tr><td style=\"text-align: center;background-color: blue;\">thing</td></tr></tbody></table>"
+    expected = "<table><thead><tr><th style=\"text-align: left;\">thing</th></tr></thead><tbody><tr><td style=\"text-align: center;\">thing</td></tr></tbody></table>"
+    assert_equal expected, Govspeak::HtmlSanitizer.new(input).sanitize
 
     [
       "width: 10000px",
-      "text-align: middle",
-      "text-align: left; width: 10px",
       "background-image: url(javascript:alert('XSS'))",
       "expression(alert('XSS'));",
     ].each do |style|

--- a/test/html_sanitizer_test.rb
+++ b/test/html_sanitizer_test.rb
@@ -17,6 +17,16 @@ class HtmlSanitizerTest < Minitest::Test
     assert_equal "<a href=\"/\">Link</a>", Govspeak::HtmlSanitizer.new(html).sanitize
   end
 
+  test "disallow style attributes" do
+    html = '<a href="/" style="font-weight:bold">Link</a>'
+    assert_equal '<a href="/">Link</a>', Govspeak::HtmlSanitizer.new(html).sanitize
+  end
+
+  test "disallow style elements" do
+    html = "<style>h1 { color: pink; }</style><h1>Hi</h1>"
+    assert_equal "<h1>Hi</h1>", Govspeak::HtmlSanitizer.new(html).sanitize
+  end
+
   test "allow non-JS HTML content" do
     html = "<a href='foo'>"
     assert_equal "<a href=\"foo\"></a>", Govspeak::HtmlSanitizer.new(html).sanitize


### PR DESCRIPTION
This forbids a user from inputting a style element as part of their
govspeak markdown or using the style attribute in their HTML.
Thus it prevents publishers from customising the style of a GOV.UK page.

I am very confident we never intended to let users do this and consider
this a bug fix - luckily, the evidence of usage is minimal. This bug
provides publishers with an unprecedented ability to re-style a GOV.UK
page in a way far outside of the GOV.UK brand guidelines.

The reason I'm confident this was not intended is because we went to
special effort to only style on table cell elements 7 years ago [1]. It
appears that when we adopted Sanitize::Config::Relaxed in 2012 [2],
style was not allowed as it was later added to Sanitize::Config::Relaxed
in 2014 [3].

The motivation for making this change is that, with the [GOV.UK Content
Security Policy](https://github.com/alphagov/govuk_app_config/pull/291)
style is blocked, so even if users could use this feature it wouldn't change
the frontend (but would generate reports).

I've been working through the apps to make sure publishers will only
have minimal effect from this change and know there's a couple of docs
in Whitehall that need fixing which will be co-ordinated with this gem release.