### PR TITLE
Bump to version 8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## Unreleased
+## 8.0.0
 
-* BREAKING: HTML style attribute and style element, which were never supposed to be available, are forbidden.
+* BREAKING: HTML style attribute and style element, which were never supposed to be available, are forbidden. [#279](https://github.com/alphagov/govspeak/pull/279)
 
 ## 7.1.1
 

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "7.1.1".freeze
+  VERSION = "8.0.0".freeze
 end


### PR DESCRIPTION
This also adds a missing PR link to the changelog.

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.


