### PR TITLE
Add margin-bottom to embedded attachments

### DIFF
--- a/lib/govspeak/post_processor.rb
+++ b/lib/govspeak/post_processor.rb
@@ -59,6 +59,7 @@ module Govspeak
         attachment_html = GovukPublishingComponents.render(
           "govuk_publishing_components/components/attachment",
           attachment: attachment,
+          margin_bottom: 6,
           locale: govspeak_document.locale,
         )
         el.swap(attachment_html)


### PR DESCRIPTION
## What

This change adds margin-bottom to embedded attachments.

Without this, attachments have zero margin-bottom, meaning they look visually 'squished up' when multiple attachments are embedded one after the other in a document.

This styling also makes it consistent with the 'Documents' section that automatically gets added to some document types (for example, Publications in Whitehall).

## Visual changes

In this example, multiple attachments have been embedded into the document one after the other.

Some pseudo Govspeak for this would be:

```
[Attachment: england_full_dataset.ods]

[Attachment: table_13_indirect_emissions.xls]

[Attachment: conversion_factors.ods]
```

| Before | After |
| --- | --- |
| <img width="627" alt="before" src="https://github.com/alphagov/govspeak/assets/7735945/6a052191-0d9c-475d-aef8-a4a016ee89c9"> | <img width="627" alt="after" src="https://github.com/alphagov/govspeak/assets/7735945/e7c46689-17a5-4f6b-b275-a90e4b65b4cf"> |

---

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.


