### PR TITLE
Allow inline attachments in numbered lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Allow attachment links wtihin numbered lists ([#283](https://github.com/alphagov/govspeak/pull/283))
+
 ## 8.0.1
 
 * Add margin-bottom to embedded attachments ([#281](https://github.com/alphagov/govspeak/pull/281))

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -380,7 +380,7 @@ module Govspeak
 
     extension("numbered list", /^[ \t]*((s\d+\.\s.*(?:\n|$))+)/) do |body|
       body.gsub!(/s(\d+)\.\s(.*)(?:\n|$)/) do
-        "<li>#{Govspeak::Document.new(Regexp.last_match(2).strip).to_html}</li>\n"
+        "<li>#{Govspeak::Document.new(Regexp.last_match(2).strip, attachments: attachments).to_html}</li>\n"
       end
       %(<ol class="steps">\n#{body}</ol>)
     end

--- a/test/govspeak_attachment_link_test.rb
+++ b/test/govspeak_attachment_link_test.rb
@@ -46,4 +46,28 @@ class GovspeakAttachmentLinkTest < Minitest::Test
     rendered = render_govspeak("[AttachmentLink: This is the name of my &%$@€? attachment]", [attachment])
     assert_match(/Attachment Title/, rendered)
   end
+
+  test "renders an attachment link inside a numbered list" do
+    attachment = {
+      id: "attachment.pdf",
+      url: "http://example.com/attachment.pdf",
+      title: "Attachment Title",
+    }
+
+    rendered = render_govspeak("s1. First item with [AttachmentLink: attachment.pdf]\ns2. Second item without attachment", [attachment])
+
+    expected_output = <<~TEXT
+      <ol class="steps">
+      <li>
+      <p>First item with <span class="gem-c-attachment-link">
+        <a class="govuk-link" href="http://example.com/attachment.pdf">Attachment Title</a>  </span></p>
+      </li>
+      <li>
+      <p>Second item without attachment</p>
+      </li>
+      </ol>
+    TEXT
+
+    assert_equal(expected_output, rendered)
+  end
 end


### PR DESCRIPTION
At the moment, inline attachments do not work if included in a numbered list.

Adding a fix to allow this, as expected by publishers.

See commit messages for implementation details.

After merging and updating the gem in Whitehall, the affected document will need to be republished.

[Trello card](https://trello.com/c/37idNKRb)