### PR TITLE
Reintroduce support for acronyms in Legislative Lists and Calls To Action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Reintroduce support for acronyms in Call To Action blocks and in Legislative Lists ([#285](https://github.com/alphagov/govspeak/pull/285))
+
 ## 8.1.0
 
 * Allow attachment links wtihin numbered lists ([#283](https://github.com/alphagov/govspeak/pull/283))

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -145,6 +145,7 @@ module Govspeak
           number = footnote[0]
           text = footnote[1].strip
           footnote_definition = Govspeak::Document.new(text).to_html[/(?<=<p>).*(?=<\/p>)/]
+          footnote_definition = add_acronym_alt_text(footnote_definition)
 
           <<~HTML_SNIPPET
             <li id="fn:#{number}" role="doc-endnote">
@@ -163,10 +164,6 @@ module Govspeak
           </div>
         HTML_CONTAINER
       end
-
-      # unless @footnote_definition_html.nil? && @acronyms.size.positive?
-      #   add_acronym_alt_text(@footnote_definition_html)
-      # end
     end
 
     def remove_forbidden_characters(source)
@@ -358,6 +355,8 @@ module Govspeak
 
     extension("legislative list", /#{NEW_PARAGRAPH_LOOKBEHIND}\$LegislativeList\s*$(.*?)\$EndLegislativeList/m) do |body|
       Govspeak::KramdownOverrides.with_kramdown_ordered_lists_disabled do
+        body = add_acronym_alt_text(body.strip)
+
         Kramdown::Document.new(body.strip).to_html.tap do |doc|
           doc.gsub!("<ul>", "<ol>")
           doc.gsub!("</ul>", "</ol>")
@@ -372,8 +371,6 @@ module Govspeak
 
             doc.sub!(/(\[\^#{footnote}\])/, html)
           end
-
-          # add_acronym_alt_text(doc) if @acronyms.size.positive?
         end
       end
     end

--- a/test/govspeak_button_test.rb
+++ b/test/govspeak_button_test.rb
@@ -118,7 +118,7 @@ class GovspeakTest < Minitest::Test
   " do
     assert_text_output "Start now JSA"
     assert_html_output %(
-      <p><a class="gem-c-button govuk-button govuk-button--start" role="button" data-module="govuk-button" draggable="false" href="https://www.apply-for-new-style-jsa.dwp.gov.uk/?lang=cy"> Start now <abbr title="Jobseeker's Allowance">JSA</abbr><svg class="govuk-button__start-icon govuk-!-display-none-print" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewbox="0 0 33 40" focusable="false" aria-hidden="true"><path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path></svg></a></p>
+      <p><a class="gem-c-button govuk-button govuk-button--start" role="button" data-module="govuk-button" draggable="false" href="https://www.apply-for-new-style-jsa.dwp.gov.uk/?lang=cy"><span> Start now <abbr title="Jobseeker's Allowance">JSA</abbr></span><svg class="govuk-button__start-icon govuk-!-display-none-print" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewbox="0 0 33 40" focusable="false" aria-hidden="true"><path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path></svg></a></p>
     )
   end
 end

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -1105,44 +1105,43 @@ Teston
     )
     end
 
-  # FIXME: this code is buggy and replaces abbreviations in HTML tags - removing the functionality for now
-  # test_given_govspeak "
-  #   $LegislativeList
-  #   * 1. Item 1[^1] with an ACRONYM
-  #   * 2. Item 2[^2]
-  #   * 3. Item 3
-  #   $EndLegislativeList
-  #
-  #   [^1]: Footnote definition one
-  #   [^2]: Footnote definition two with an ACRONYM
-  #
-  #   *[ACRONYM]: This is the acronym explanation
-  # " do
-  #   assert_html_output %(
-  #     <ol class="legislative-list">
-  #       <li>1. Item 1<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup> with an <abbr title="This is the acronym explanation">ACRONYM</abbr>
-  #     </li>
-  #       <li>2. Item 2<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup>
-  #     </li>
-  #       <li>3. Item 3</li>
-  #     </ol>
-  #
-  #     <div class="footnotes" role="doc-endnotes">
-  #       <ol>
-  #         <li id="fn:1" role="doc-endnote">
-  #       <p>
-  #         Footnote definition one<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-  #       </p>
-  #     </li>
-  #     <li id="fn:2" role="doc-endnote">
-  #       <p>
-  #         Footnote definition two with an <abbr title="This is the acronym explanation">ACRONYM</abbr><a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-  #       </p>
-  #     </li>
-  #       </ol>
-  #     </div>
-  #   )
-  # end
+  test_given_govspeak "
+    $LegislativeList
+    * 1. Item 1[^1] with an ACRONYM
+    * 2. Item 2[^2]
+    * 3. Item 3
+    $EndLegislativeList
+
+    [^1]: Footnote definition one
+    [^2]: Footnote definition two with an ACRONYM
+
+    *[ACRONYM]: This is the acronym explanation
+  " do
+    assert_html_output %(
+      <ol class="legislative-list">
+        <li>1. Item 1<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup> with an <abbr title="This is the acronym explanation">ACRONYM</abbr>
+      </li>
+        <li>2. Item 2<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup>
+      </li>
+        <li>3. Item 3</li>
+      </ol>
+
+      <div class="footnotes" role="doc-endnotes">
+        <ol>
+          <li id="fn:1" role="doc-endnote">
+        <p>
+          Footnote definition one<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
+        </p>
+      </li>
+      <li id="fn:2" role="doc-endnote">
+        <p>
+          Footnote definition two with an <abbr title="This is the acronym explanation">ACRONYM</abbr><a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
+        </p>
+      </li>
+        </ol>
+      </div>
+    )
+  end
 
   test_given_govspeak "
     The quick brown

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -623,6 +623,21 @@ Teston
   end
 
   test_given_govspeak "
+    $CTA
+    Contact the SGD on 0800 000 0000 or contact the OGD on 0800 001 0001
+    $CTA
+
+    *[OGD]: Other Government Department
+    *[SGD]: Some Government Department
+    " do
+    assert_html_output %(
+      <div class="call-to-action">
+      <p>Contact the <abbr title="Some Government Department">SGD</abbr> on 0800 000 0000 or contact the <abbr title="Other Government Department">OGD</abbr> on 0800 001 0001</p>
+      </div>
+    )
+  end
+
+  test_given_govspeak "
     1. rod
     2. jane
     3. freddy" do

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -624,15 +624,15 @@ Teston
 
   test_given_govspeak "
     $CTA
-    Contact the SGD on 0800 000 0000 or contact the OGD on 0800 001 0001
+    Contact the SGD on 0800 000 0000 or contact the class on 0800 001 0001
     $CTA
 
-    *[OGD]: Other Government Department
+    *[class]: Other Government Department
     *[SGD]: Some Government Department
     " do
     assert_html_output %(
       <div class="call-to-action">
-      <p>Contact the <abbr title="Some Government Department">SGD</abbr> on 0800 000 0000 or contact the <abbr title="Other Government Department">OGD</abbr> on 0800 001 0001</p>
+      <p>Contact the <abbr title="Some Government Department">SGD</abbr> on 0800 000 0000 or contact the <abbr title="Other Government Department">class</abbr> on 0800 001 0001</p>
       </div>
     )
   end
@@ -1109,13 +1109,15 @@ Teston
     $LegislativeList
     * 1. Item 1[^1] with an ACRONYM
     * 2. Item 2[^2]
-    * 3. Item 3
+    * 3. Item 3[^3]
     $EndLegislativeList
 
     [^1]: Footnote definition one
     [^2]: Footnote definition two with an ACRONYM
+    [^3]: Footnote definition three with an acronym that matches an HTML tag class
 
     *[ACRONYM]: This is the acronym explanation
+    *[class]: Testing HTML matching
   " do
     assert_html_output %(
       <ol class="legislative-list">
@@ -1123,7 +1125,8 @@ Teston
       </li>
         <li>2. Item 2<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup>
       </li>
-        <li>3. Item 3</li>
+        <li>3. Item 3<sup id="fnref:3" role="doc-noteref"><a href="#fn:3" class="footnote" rel="footnote">[footnote 3]</a></sup>
+      </li>
       </ol>
 
       <div class="footnotes" role="doc-endnotes">
@@ -1136,6 +1139,11 @@ Teston
       <li id="fn:2" role="doc-endnote">
         <p>
           Footnote definition two with an <abbr title="This is the acronym explanation">ACRONYM</abbr><a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
+        </p>
+      </li>
+      <li id="fn:3" role="doc-endnote">
+        <p>
+          Footnote definition three with an acronym that matches an HTML tag <abbr title="Testing HTML matching">class</abbr><a href="#fnref:3" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
         </p>
       </li>
         </ol>


### PR DESCRIPTION
This adds support for acronyms in Legislative Lists and Calls to Action, which was removed in https://github.com/alphagov/govspeak/pull/229.

The removal was because acronyms that matched parts of the HTML tags/attributes were also being replaced with acronym markup.

Therefore resolving this by searching for acronyms before converting to HTML.

[Trello card](https://trello.com/c/zzYVzGFM)