### PR TITLE
Prevent user error when incorrectly formatted footnotes are added to HTML attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Prevent user error when incorrectly formatted footnotes are added to HTML attachments ([#287](https://github.com/alphagov/govspeak/pull/287))
+
 ## 8.2.0
 
 * Reintroduce support for acronyms in Call To Action blocks and in Legislative Lists ([#285](https://github.com/alphagov/govspeak/pull/285))

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -451,6 +451,8 @@ module Govspeak
     end
 
     def add_acronym_alt_text(html)
+      return unless html
+
       @acronyms.each do |acronym|
         html.gsub!(acronym[0], "<abbr title=\"#{acronym[1].strip}\">#{acronym[0]}</abbr>")
       end


### PR DESCRIPTION
When incorrectly formatted footnotes are used on HTML attachments in Whitehall, the function would cause an unhelpful user error to be displayed.

`html.gsub!` seemed to crash with footnotes in an attachment, as `html` was nil: https://govuk.sentry.io/issues/4415164546/?project=202259&query=is%3Aunresolved&referrer=issue-stream&stream_index=0

This will allow the attachment to save.

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.


