### PR TITLE
Parse call to action as part of the main conversion

### DIFF
--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -137,10 +137,9 @@ module Govspeak
 
     def footnote_definitions(source)
       is_legislative_list = source.scan(/\$LegislativeList.*?\[\^\d\]*.*?\$EndLegislativeList/m).size.positive?
-      is_cta = source.scan(/\$CTA.*?\[\^\d\]*.*?\$CTA/m).size.positive?
       footnotes = source.scan(/^\s*\[\^(\d+)\]:(.*)/)
       @acronyms.concat(source.scan(/(?<=\*)\[(.*)\]:(.*)/))
-      if (is_legislative_list || is_cta) && footnotes.size.positive?
+      if is_legislative_list && footnotes.size.positive?
         list_items = footnotes.map do |footnote|
           number = footnote[0]
           text = footnote[1].strip
@@ -322,20 +321,11 @@ module Govspeak
     end
 
     extension("call-to-action", surrounded_by("$CTA")) do |body|
-      doc = Kramdown::Document.new(preprocess(body.strip), @options).to_html
-      doc = add_acronym_alt_text(doc)
-      doc = %(\n<div class="call-to-action">\n#{doc}</div>\n)
-      footnotes = body.scan(/\[\^(\d+)\]/).flatten
-
-      footnotes.each do |footnote|
-        html = "<sup id=\"fnref:#{footnote}\" role=\"doc-noteref\">" \
-        "<a href=\"#fn:#{footnote}\" class=\"footnote\" rel=\"footnote\">" \
-        "[footnote #{footnote}]</a></sup>"
-
-        doc.sub!(/(\[\^#{footnote}\])/, html)
-      end
-
-      doc
+      <<~BODY
+        {::options parse_block_html=\"true\" /}
+        <div class="call-to-action">#{body}</div>
+        {::options parse_block_html=\"false\" /}
+      BODY
     end
 
     # More specific tags must be defined first. Those defined earlier have a

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -420,13 +420,13 @@ Teston
     $CTA" do
     assert_html_output %(
       <div class="call-to-action">
-      <p>Click here to start the tool</p>
+        <p>Click here to start the tool</p>
       </div>)
     assert_text_output "Click here to start the tool"
   end
 
   test_given_govspeak "
-    Here is some text
+    Here is some text\n
 
     $CTA
     Click here to start the tool
@@ -436,7 +436,7 @@ Teston
       <p>Here is some text</p>
 
       <div class="call-to-action">
-      <p>Click here to start the tool</p>
+        <p>Click here to start the tool</p>
       </div>)
   end
 
@@ -453,9 +453,10 @@ Teston
     $CTA" do
     assert_html_output %(
         <div class="call-to-action">
-        <p>This is a test:</p>
 
-        <ol class="steps">
+          <p>This is a test:</p>
+
+          <ol class="steps">
         <li>
         <p>This is number 1.</p>
         </li>
@@ -480,7 +481,7 @@ Teston
     " do
     assert_html_output %(
       <div class="call-to-action">
-      <p><a rel="external" href="http://www.external.com">external link</a> some text</p>
+        <p><a rel="external" href="http://www.external.com">external link</a> some text</p>
       </div>)
   end
 
@@ -490,7 +491,7 @@ Teston
     $CTA", document_domains: %w[www.not-external.com] do
     assert_html_output %(
       <div class="call-to-action">
-      <p><a href="http://www.not-external.com">internal link</a> some text</p>
+        <p><a href="http://www.not-external.com">internal link</a> some text</p>
       </div>)
   end
 
@@ -505,7 +506,7 @@ Teston
     " do
     assert_html_output %(
       <div class="call-to-action">
-      <p>Click here to start the tool</p>
+        <p>Click here to start the tool</p>
       </div>
 
       <div class="contact">
@@ -514,7 +515,7 @@ Teston
   end
 
   test_given_govspeak "
-    [internal link](http://www.not-external.com)
+    [internal link](http://www.not-external.com)\n
 
     $CTA
     Click here to start the tool
@@ -523,7 +524,7 @@ Teston
       <p><a href="http://www.not-external.com">internal link</a></p>
 
       <div class="call-to-action">
-      <p>Click here to start the tool</p>
+        <p>Click here to start the tool</p>
       </div>)
   end
 
@@ -535,15 +536,13 @@ Teston
     " do
     assert_html_output %(
       <div class="call-to-action">
-      <p>Click here to start the tool<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup></p>
+        <p>Click here to start the tool<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup></p>
       </div>
       <div class="footnotes" role="doc-endnotes">
         <ol>
           <li id="fn:1" role="doc-endnote">
-        <p>
-          Footnote definition one<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
+            <p>Footnote definition one <a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
         </ol>
       </div>
     )
@@ -563,26 +562,21 @@ Teston
     " do
     assert_html_output %(
       <div class="call-to-action">
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
       Fusce felis ante<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup>, lobortis non quam sit amet, tempus interdum justo.</p>
       </div>
-
       <div class="call-to-action">
-      <p>Pellentesque quam enim, egestas sit amet congue sit amet<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup>, ultrices vitae arcu.
+        <p>Pellentesque quam enim, egestas sit amet congue sit amet<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup>, ultrices vitae arcu.
       Fringilla, metus dui scelerisque est.</p>
       </div>
       <div class="footnotes" role="doc-endnotes">
         <ol>
           <li id="fn:1" role="doc-endnote">
-        <p>
-          Footnote definition one<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-      <li id="fn:2" role="doc-endnote">
-        <p>
-          Footnote definition two<a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
+            <p>Footnote definition one <a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
+          <li id="fn:2" role="doc-endnote">
+            <p>Footnote definition two <a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
         </ol>
       </div>
     )
@@ -600,7 +594,7 @@ Teston
     " do
     assert_html_output %(
       <div class="call-to-action">
-      <p>Click here to start the tool<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup></p>
+        <p>Click here to start the tool<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup></p>
       </div>
 
       <p>Lorem ipsum dolor sit amet<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup></p>
@@ -608,15 +602,11 @@ Teston
       <div class="footnotes" role="doc-endnotes">
         <ol>
           <li id="fn:1" role="doc-endnote">
-        <p>
-          Footnote definition 1<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-      <li id="fn:2" role="doc-endnote">
-        <p>
-          Footnote definition 2<a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
+            <p>Footnote definition 1 <a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
+          <li id="fn:2" role="doc-endnote">
+            <p>Footnote definition 2 <a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
         </ol>
       </div>
     )
@@ -632,7 +622,7 @@ Teston
     " do
     assert_html_output %(
       <div class="call-to-action">
-      <p>Contact the <abbr title="Some Government Department">SGD</abbr> on 0800 000 0000 or contact the <abbr title="Other Government Department">class</abbr> on 0800 001 0001</p>
+        <p>Contact the <abbr title="Some Government Department">SGD</abbr> on 0800 000 0000 or contact the <abbr title="Other Government Department">class</abbr> on 0800 001 0001</p>
       </div>
     )
   end


### PR DESCRIPTION
https://trello.com/c/I15QapuL

Currently, we do a lot of work to replicate various functions of Kramdown (acronyms and footnotes) in the call to action and legislative list components.

The acronym function has been proved to contains bugs through several Zendesk tickets.

1. Acronyms are inserted into the produced HTML, even if undesirable. For example, a link `<email@example.com>` with the acronym `*[email]: Electronic mail is a method of transmitting and receiving messages` would produce `<p>href="mailto:<abbr title="Electronic mail is a method of transmitting and receiving messages">email</abbr>@example.com"<abbr title="Electronic mail is a method of transmitting and receiving messages">email</abbr>@example.com</p>` rather than the expected link.

2. Because the `add_acronym_alt_text` method runs through the text for each acronym, acronyms can be inserted into other acronyms creating invalid HTML.

Both of these issues can be prevented by parsing the call to action component as part of the main conversion to HTML. Kramdown syntax is normally not processed inside an HTML tag, but can be enabled with the `parse_block_html` option.

There is a small regression in that the `$CTA` block must be proceeded by a blank line (demonstrated in `test/govspeak_test.rb:428`), but this seems okay as it's standard markdown.

Some of the tests can likely be removed as we are now testing the functionality of the library, however, for now these represent that there are no regressions.

## Example
```
$CTA
Welcome to the GOV.UK website <website@lo.com> [^1]
$CTA

*[GOV.UK]: The official UK government website
*[footnote]: The official UK government website
*[website]: A collection of web pages, such as GOV.UK

[^1]: website
```

BEFORE 
![image](https://github.com/alphagov/govspeak/assets/47089130/d8ca69a5-8d53-4236-a2fb-3fb496ef94fc)

AFTER (both abbr work)
<img width="430" alt="image" src="https://github.com/alphagov/govspeak/assets/47089130/7a913328-e40b-4831-b9b7-c47512cb541b">

---



This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.


