### PR TITLE
Fix abbreviation bugs in CTA and LegislativeList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.3.0
+
+* Various bug fixes related to abbreviations in call to action and legislative list components ([#291](https://github.com/alphagov/govspeak/pull/291))
+
 ## 8.2.1
 
 * Prevent user error when incorrectly formatted footnotes are added to HTML attachments ([#287](https://github.com/alphagov/govspeak/pull/287))

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -137,10 +137,9 @@ module Govspeak
 
     def footnote_definitions(source)
       is_legislative_list = source.scan(/\$LegislativeList.*?\[\^\d\]*.*?\$EndLegislativeList/m).size.positive?
-      is_cta = source.scan(/\$CTA.*?\[\^\d\]*.*?\$CTA/m).size.positive?
       footnotes = source.scan(/^\s*\[\^(\d+)\]:(.*)/)
       @acronyms.concat(source.scan(/(?<=\*)\[(.*)\]:(.*)/))
-      if (is_legislative_list || is_cta) && footnotes.size.positive?
+      if is_legislative_list && footnotes.size.positive?
         list_items = footnotes.map do |footnote|
           number = footnote[0]
           text = footnote[1].strip
@@ -322,20 +321,11 @@ module Govspeak
     end
 
     extension("call-to-action", surrounded_by("$CTA")) do |body|
-      doc = Kramdown::Document.new(preprocess(body.strip), @options).to_html
-      doc = add_acronym_alt_text(doc)
-      doc = %(\n<div class="call-to-action">\n#{doc}</div>\n)
-      footnotes = body.scan(/\[\^(\d+)\]/).flatten
-
-      footnotes.each do |footnote|
-        html = "<sup id=\"fnref:#{footnote}\" role=\"doc-noteref\">" \
-        "<a href=\"#fn:#{footnote}\" class=\"footnote\" rel=\"footnote\">" \
-        "[footnote #{footnote}]</a></sup>"
-
-        doc.sub!(/(\[\^#{footnote}\])/, html)
-      end
-
-      doc
+      <<~BODY
+        {::options parse_block_html=\"true\" /}
+        <div class="call-to-action">#{body}</div>
+        {::options parse_block_html=\"false\" /}
+      BODY
     end
 
     # More specific tags must be defined first. Those defined earlier have a

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -63,8 +63,6 @@ module Govspeak
                    sanitize: true,
                    syntax_highlighter: nil }.merge(options)
       @options[:entity_output] = :symbolic
-      @footnote_definition_html = nil
-      @acronyms = []
     end
 
     def to_html
@@ -75,16 +73,6 @@ module Govspeak
                else
                  kramdown_doc.to_html
                end
-
-        unless @footnote_definition_html.nil?
-          regex = /<div class="footnotes".*[<\/div>]/m
-
-          if html.scan(regex).empty?
-            html << @footnote_definition_html
-          else
-            html.gsub!(regex, @footnote_definition_html)
-          end
-        end
 
         Govspeak::PostProcessor.process(html, self)
       end
@@ -125,44 +113,12 @@ module Govspeak
       source = Govspeak::BlockquoteExtraQuoteRemover.remove(source)
       source = remove_forbidden_characters(source)
 
-      footnote_definitions(source)
-
       self.class.extensions.each do |_, regexp, block|
         source.gsub!(regexp) do
           instance_exec(*Regexp.last_match.captures, &block)
         end
       end
       source
-    end
-
-    def footnote_definitions(source)
-      is_legislative_list = source.scan(/\$LegislativeList.*?\[\^\d\]*.*?\$EndLegislativeList/m).size.positive?
-      footnotes = source.scan(/^\s*\[\^(\d+)\]:(.*)/)
-      @acronyms.concat(source.scan(/(?<=\*)\[(.*)\]:(.*)/))
-      if is_legislative_list && footnotes.size.positive?
-        list_items = footnotes.map do |footnote|
-          number = footnote[0]
-          text = footnote[1].strip
-          footnote_definition = Govspeak::Document.new(text).to_html[/(?<=<p>).*(?=<\/p>)/]
-          footnote_definition = add_acronym_alt_text(footnote_definition)
-
-          <<~HTML_SNIPPET
-            <li id="fn:#{number}" role="doc-endnote">
-              <p>
-                #{footnote_definition}<a href="#fnref:#{number}" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-              </p>
-            </li>
-          HTML_SNIPPET
-        end
-
-        @footnote_definition_html = <<~HTML_CONTAINER
-          <div class="footnotes" role="doc-endnotes">
-            <ol>
-              #{list_items.join.strip}
-            </ol>
-          </div>
-        HTML_CONTAINER
-      end
     end
 
     def remove_forbidden_characters(source)
@@ -344,25 +300,13 @@ module Govspeak
     end
 
     extension("legislative list", /#{NEW_PARAGRAPH_LOOKBEHIND}\$LegislativeList\s*$(.*?)\$EndLegislativeList/m) do |body|
-      Govspeak::KramdownOverrides.with_kramdown_ordered_lists_disabled do
-        body = add_acronym_alt_text(body.strip)
-
-        Kramdown::Document.new(body.strip).to_html.tap do |doc|
-          doc.gsub!("<ul>", "<ol>")
-          doc.gsub!("</ul>", "</ol>")
-          doc.sub!("<ol>", '<ol class="legislative-list">')
-
-          footnotes = body.scan(/\[\^(\d+)\]/).flatten
-
-          footnotes.each do |footnote|
-            html = "<sup id=\"fnref:#{footnote}\" role=\"doc-noteref\">" \
-            "<a href=\"#fn:#{footnote}\" class=\"footnote\" rel=\"footnote\">" \
-            "[footnote #{footnote}]</a></sup>"
-
-            doc.sub!(/(\[\^#{footnote}\])/, html)
-          end
-        end
-      end
+      # The surrounding div is neccessary to control flow in `parse_block_html` and
+      # maintain the same functionality as a previous version of this extension.
+      <<~BODY
+        {::options parse_block_html=\"true\" ordered_lists_disabled=\"true\" /}
+        <div class="legislative-list-wrapper">#{body}</div>
+        {::options parse_block_html=\"false\" ordered_lists_disabled=\"false\" /}
+      BODY
     end
 
     extension("numbered list", /^[ \t]*((s\d+\.\s.*(?:\n|$))+)/) do |body|
@@ -438,16 +382,6 @@ module Govspeak
 
     def encode(text)
       HTMLEntities.new.encode(text)
-    end
-
-    def add_acronym_alt_text(html)
-      return unless html
-
-      @acronyms.each do |acronym|
-        html.gsub!(acronym[0], "<abbr title=\"#{acronym[1].strip}\">#{acronym[0]}</abbr>")
-      end
-
-      html
     end
   end
 end

--- a/lib/govspeak/post_processor.rb
+++ b/lib/govspeak/post_processor.rb
@@ -20,6 +20,15 @@ module Govspeak
       end
     end
 
+    extension("covert legislative list ul to ol") do |document|
+      document.css(".legislative-list-wrapper").map do |el|
+        el.inner_html = el.inner_html
+            .sub("<ul>", "<ol class=\"legislative-list\">")
+            .gsub("</ul>", "</ol>")
+            .gsub("<ul>", "<ol>")
+      end
+    end
+
     # This "fix" here is tied into the rendering of images as one of the
     # pre-processor tasks. As images can be created inside block level elements
     # it's possible that their block level elements can be HTML entity escaped

--- a/lib/kramdown/parser/govuk.rb
+++ b/lib/kramdown/parser/govuk.rb
@@ -17,6 +17,13 @@ module Kramdown
     DESCRIPTION
       simple_array_validator(val, :document_domains, AlwaysEqual.new)
     end
+
+    define(:ordered_lists_disabled, Boolean, false, <<~DESCRIPTION)
+      Disables ordered lists
+
+      Default: false
+      Used by: KramdownWithAutomaticExternalLinks
+    DESCRIPTION
   end
 
   module Parser
@@ -46,7 +53,17 @@ module Kramdown
       def parse_block_html
         return false if CUSTOM_INLINE_ELEMENTS.include?(@src[1].downcase)
 
-        super
+        return super unless @options[:ordered_lists_disabled]
+
+        # Kramdown loads parsers into the instance from `options` which are scoped to
+        # the class. Because we are changing these options inside an instance, we must
+        # reconfigure the parser before and after disbaling ordered lists.
+        Govspeak::KramdownOverrides.with_kramdown_ordered_lists_disabled do
+          configure_parser
+          super
+        end
+
+        configure_parser
       end
     end
   end

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -420,13 +420,13 @@ Teston
     $CTA" do
     assert_html_output %(
       <div class="call-to-action">
-      <p>Click here to start the tool</p>
+        <p>Click here to start the tool</p>
       </div>)
     assert_text_output "Click here to start the tool"
   end
 
   test_given_govspeak "
-    Here is some text
+    Here is some text\n
 
     $CTA
     Click here to start the tool
@@ -436,7 +436,7 @@ Teston
       <p>Here is some text</p>
 
       <div class="call-to-action">
-      <p>Click here to start the tool</p>
+        <p>Click here to start the tool</p>
       </div>)
   end
 
@@ -453,9 +453,10 @@ Teston
     $CTA" do
     assert_html_output %(
         <div class="call-to-action">
-        <p>This is a test:</p>
 
-        <ol class="steps">
+          <p>This is a test:</p>
+
+          <ol class="steps">
         <li>
         <p>This is number 1.</p>
         </li>
@@ -480,7 +481,7 @@ Teston
     " do
     assert_html_output %(
       <div class="call-to-action">
-      <p><a rel="external" href="http://www.external.com">external link</a> some text</p>
+        <p><a rel="external" href="http://www.external.com">external link</a> some text</p>
       </div>)
   end
 
@@ -490,7 +491,7 @@ Teston
     $CTA", document_domains: %w[www.not-external.com] do
     assert_html_output %(
       <div class="call-to-action">
-      <p><a href="http://www.not-external.com">internal link</a> some text</p>
+        <p><a href="http://www.not-external.com">internal link</a> some text</p>
       </div>)
   end
 
@@ -505,7 +506,7 @@ Teston
     " do
     assert_html_output %(
       <div class="call-to-action">
-      <p>Click here to start the tool</p>
+        <p>Click here to start the tool</p>
       </div>
 
       <div class="contact">
@@ -514,7 +515,7 @@ Teston
   end
 
   test_given_govspeak "
-    [internal link](http://www.not-external.com)
+    [internal link](http://www.not-external.com)\n
 
     $CTA
     Click here to start the tool
@@ -523,7 +524,7 @@ Teston
       <p><a href="http://www.not-external.com">internal link</a></p>
 
       <div class="call-to-action">
-      <p>Click here to start the tool</p>
+        <p>Click here to start the tool</p>
       </div>)
   end
 
@@ -535,15 +536,13 @@ Teston
     " do
     assert_html_output %(
       <div class="call-to-action">
-      <p>Click here to start the tool<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup></p>
+        <p>Click here to start the tool<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup></p>
       </div>
       <div class="footnotes" role="doc-endnotes">
         <ol>
           <li id="fn:1" role="doc-endnote">
-        <p>
-          Footnote definition one<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
+            <p>Footnote definition one <a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
         </ol>
       </div>
     )
@@ -563,26 +562,21 @@ Teston
     " do
     assert_html_output %(
       <div class="call-to-action">
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
       Fusce felis ante<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup>, lobortis non quam sit amet, tempus interdum justo.</p>
       </div>
-
       <div class="call-to-action">
-      <p>Pellentesque quam enim, egestas sit amet congue sit amet<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup>, ultrices vitae arcu.
+        <p>Pellentesque quam enim, egestas sit amet congue sit amet<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup>, ultrices vitae arcu.
       Fringilla, metus dui scelerisque est.</p>
       </div>
       <div class="footnotes" role="doc-endnotes">
         <ol>
           <li id="fn:1" role="doc-endnote">
-        <p>
-          Footnote definition one<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-      <li id="fn:2" role="doc-endnote">
-        <p>
-          Footnote definition two<a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
+            <p>Footnote definition one <a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
+          <li id="fn:2" role="doc-endnote">
+            <p>Footnote definition two <a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
         </ol>
       </div>
     )
@@ -600,7 +594,7 @@ Teston
     " do
     assert_html_output %(
       <div class="call-to-action">
-      <p>Click here to start the tool<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup></p>
+        <p>Click here to start the tool<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup></p>
       </div>
 
       <p>Lorem ipsum dolor sit amet<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup></p>
@@ -608,15 +602,11 @@ Teston
       <div class="footnotes" role="doc-endnotes">
         <ol>
           <li id="fn:1" role="doc-endnote">
-        <p>
-          Footnote definition 1<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-      <li id="fn:2" role="doc-endnote">
-        <p>
-          Footnote definition 2<a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
+            <p>Footnote definition 1 <a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
+          <li id="fn:2" role="doc-endnote">
+            <p>Footnote definition 2 <a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
         </ol>
       </div>
     )
@@ -632,7 +622,63 @@ Teston
     " do
     assert_html_output %(
       <div class="call-to-action">
-      <p>Contact the <abbr title="Some Government Department">SGD</abbr> on 0800 000 0000 or contact the <abbr title="Other Government Department">class</abbr> on 0800 001 0001</p>
+        <p>Contact the <abbr title="Some Government Department">SGD</abbr> on 0800 000 0000 or contact the <abbr title="Other Government Department">class</abbr> on 0800 001 0001</p>
+      </div>
+    )
+  end
+
+  test_given_govspeak "
+    $CTA
+    Welcome to the GOV.UK website
+    $CTA
+
+    *[GOV.UK]: The official UK government website
+    *[website]: A collection of web pages, such as GOV.UK
+    " do
+    assert_html_output %(
+      <div class="call-to-action">
+        <p>Welcome to the <abbr title="The official UK government website">GOV.UK</abbr> <abbr title="A collection of web pages, such as GOV.UK">website</abbr></p>
+      </div>
+    )
+  end
+
+  test_given_govspeak "
+    $CTA
+    Please email <developer@digital.cabinet-office.GOV.UK>
+    $CTA
+
+    *[GOV.UK]: The official UK government website
+    " do
+    assert_html_output %(
+      <div class="call-to-action">
+        <p>Please email <a href="mailto:developer@digital.cabinet-office.GOV.UK">developer@digital.cabinet-office.<abbr title="The official UK government website">GOV.UK</abbr></a></p>
+      </div>
+    )
+  end
+
+  test_given_govspeak "
+    $CTA
+    Welcome to the GOV.UK[^1]
+    $CTA
+
+    [^1]: GOV.UK is the official UK government website
+
+    *[GOV.UK]: The official UK government website
+    *[website]: A collection of web pages, such as GOV.UK
+
+    *[GOV.UK]: The official UK government website
+    " do
+    assert_html_output %(
+      <div class="call-to-action">
+        <p>Welcome to the <abbr title="The official UK government website">GOV.UK</abbr><sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup></p>
+      </div>
+
+      <div class="footnotes" role="doc-endnotes">
+        <ol>
+          <li id="fn:1" role="doc-endnote">
+            <p><abbr title="The official UK government website">GOV.UK</abbr> is the official UK government <abbr title="A collection of web pages, such as GOV.UK">website</abbr> <a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
+        </ol>
       </div>
     )
   end

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -753,13 +753,14 @@ Teston
     $EndLegislativeList
   " do
     assert_html_output %{
+    <div class="legislative-list-wrapper">
       <ol class="legislative-list">
         <li>
           <p>1.0 Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-      Fusce felis ante, lobortis non quam sit amet, tempus interdum justo.</p>
+    Fusce felis ante, lobortis non quam sit amet, tempus interdum justo.</p>
 
           <p>Pellentesque quam enim, egestas sit amet congue sit amet, ultrices vitae arcu.
-      fringilla, metus dui scelerisque est.</p>
+    fringilla, metus dui scelerisque est.</p>
 
           <ol>
             <li>
@@ -772,10 +773,11 @@ Teston
         </li>
         <li>
           <p>1.1 Second entry
-      Curabitur pretium pharetra sapien, a feugiat arcu euismod eget.
-      Nunc luctus ornare varius. Nulla scelerisque, justo dictum dapibus</p>
+    Curabitur pretium pharetra sapien, a feugiat arcu euismod eget.
+    Nunc luctus ornare varius. Nulla scelerisque, justo dictum dapibus</p>
         </li>
-      </ol>}
+      </ol>
+    </div>}
   end
 
   test_given_govspeak "
@@ -788,6 +790,7 @@ Teston
     $EndLegislativeList
   " do
     assert_html_output %{
+    <div class="legislative-list-wrapper">
       <ol class="legislative-list">
         <li>1. The quick</li>
         <li>2. Brown fox
@@ -798,6 +801,7 @@ Teston
         </li>
         <li>3. Dog</li>
       </ol>
+    </div>
     }
   end
 
@@ -812,28 +816,26 @@ Teston
     [^2]: Footnote definition two
   " do
     assert_html_output %(
+    <div class="legislative-list-wrapper">
       <ol class="legislative-list">
         <li>1. Item 1<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup>
-      </li>
+    </li>
         <li>2. Item 2<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup>
-      </li>
+    </li>
         <li>3. Item 3</li>
       </ol>
+    </div>
 
-      <div class="footnotes" role="doc-endnotes">
-        <ol>
-          <li id="fn:1" role="doc-endnote">
-        <p>
-          Footnote definition one<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-      <li id="fn:2" role="doc-endnote">
-        <p>
-          Footnote definition two<a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-        </ol>
-      </div>
+    <div class="footnotes" role="doc-endnotes">
+      <ol>
+        <li id="fn:1" role="doc-endnote">
+          <p>Footnote definition one <a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+        </li>
+        <li id="fn:2" role="doc-endnote">
+          <p>Footnote definition two <a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+        </li>
+      </ol>
+    </div>
     )
   end
 
@@ -857,41 +859,39 @@ Teston
     [^3]: Footnote definition two
   " do
     assert_html_output %(
+    <div class="legislative-list-wrapper">
       <ol class="legislative-list">
         <li>1. Item 1<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup>
-      </li>
+    </li>
         <li>2. Item 2</li>
         <li>3. Item 3</li>
       </ol>
+    </div>
 
-      <p>This is a paragraph with a footnote<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup>.</p>
+    <p>This is a paragraph with a footnote<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup>.</p>
 
+    <div class="legislative-list-wrapper">
       <ol class="legislative-list">
         <li>1. Item 1</li>
         <li>2. Item 2<sup id="fnref:3" role="doc-noteref"><a href="#fn:3" class="footnote" rel="footnote">[footnote 3]</a></sup>
-      </li>
+    </li>
         <li>3. Item 3</li>
       </ol>
+    </div>
 
-      <div class="footnotes" role="doc-endnotes">
-        <ol>
-          <li id="fn:1" role="doc-endnote">
-        <p>
-          Footnote definition one<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-      <li id="fn:2" role="doc-endnote">
-        <p>
-          Footnote definition two<a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-      <li id="fn:3" role="doc-endnote">
-        <p>
-          Footnote definition two<a href="#fnref:3" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-        </ol>
-      </div>
+    <div class="footnotes" role="doc-endnotes">
+      <ol>
+        <li id="fn:1" role="doc-endnote">
+          <p>Footnote definition one <a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+        </li>
+        <li id="fn:2" role="doc-endnote">
+          <p>Footnote definition two <a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+        </li>
+        <li id="fn:3" role="doc-endnote">
+          <p>Footnote definition two <a href="#fnref:3" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+        </li>
+      </ol>
+    </div>
     )
   end
 
@@ -934,101 +934,83 @@ Teston
     [^12]: Footnote definition 12
   " do
     assert_html_output %(
-      <ol class="legislative-list">
-        <li>1. Item 1<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup>
+      <div class="legislative-list-wrapper">
+        <ol class="legislative-list">
+          <li>1. Item 1<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup>
       </li>
-        <li>2. Item 2<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup>
+          <li>2. Item 2<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup>
       </li>
-        <li>3. Item 3<sup id="fnref:3" role="doc-noteref"><a href="#fn:3" class="footnote" rel="footnote">[footnote 3]</a></sup>
+          <li>3. Item 3<sup id="fnref:3" role="doc-noteref"><a href="#fn:3" class="footnote" rel="footnote">[footnote 3]</a></sup>
       </li>
-      </ol>
+        </ol>
+      </div>
 
       <p>This is a paragraph with a footnote<sup id="fnref:4" role="doc-noteref"><a href="#fn:4" class="footnote" rel="footnote">[footnote 4]</a></sup>.</p>
 
-      <ol class="legislative-list">
-        <li>1. Item 1<sup id="fnref:5" role="doc-noteref"><a href="#fn:5" class="footnote" rel="footnote">[footnote 5]</a></sup>
+      <div class="legislative-list-wrapper">
+        <ol class="legislative-list">
+          <li>1. Item 1<sup id="fnref:5" role="doc-noteref"><a href="#fn:5" class="footnote" rel="footnote">[footnote 5]</a></sup>
       </li>
-        <li>2. Item 2<sup id="fnref:6" role="doc-noteref"><a href="#fn:6" class="footnote" rel="footnote">[footnote 6]</a></sup>
+          <li>2. Item 2<sup id="fnref:6" role="doc-noteref"><a href="#fn:6" class="footnote" rel="footnote">[footnote 6]</a></sup>
       </li>
-        <li>3. Item 3<sup id="fnref:7" role="doc-noteref"><a href="#fn:7" class="footnote" rel="footnote">[footnote 7]</a></sup>
+          <li>3. Item 3<sup id="fnref:7" role="doc-noteref"><a href="#fn:7" class="footnote" rel="footnote">[footnote 7]</a></sup>
       </li>
-      </ol>
+        </ol>
+      </div>
 
       <p>This is a paragraph with a footnote<sup id="fnref:8" role="doc-noteref"><a href="#fn:8" class="footnote" rel="footnote">[footnote 8]</a></sup>.</p>
 
-      <ol class="legislative-list">
-        <li>1. Item 1<sup id="fnref:9" role="doc-noteref"><a href="#fn:9" class="footnote" rel="footnote">[footnote 9]</a></sup>
+      <div class="legislative-list-wrapper">
+        <ol class="legislative-list">
+          <li>1. Item 1<sup id="fnref:9" role="doc-noteref"><a href="#fn:9" class="footnote" rel="footnote">[footnote 9]</a></sup>
       </li>
-        <li>2. Item 2<sup id="fnref:10" role="doc-noteref"><a href="#fn:10" class="footnote" rel="footnote">[footnote 10]</a></sup>
+          <li>2. Item 2<sup id="fnref:10" role="doc-noteref"><a href="#fn:10" class="footnote" rel="footnote">[footnote 10]</a></sup>
       </li>
-        <li>3. Item 3<sup id="fnref:11" role="doc-noteref"><a href="#fn:11" class="footnote" rel="footnote">[footnote 11]</a></sup>
+          <li>3. Item 3<sup id="fnref:11" role="doc-noteref"><a href="#fn:11" class="footnote" rel="footnote">[footnote 11]</a></sup>
       </li>
-      </ol>
+        </ol>
+      </div>
 
       <p>This is a paragraph with a footnote<sup id="fnref:12" role="doc-noteref"><a href="#fn:12" class="footnote" rel="footnote">[footnote 12]</a></sup>.</p>
 
       <div class="footnotes" role="doc-endnotes">
         <ol>
           <li id="fn:1" role="doc-endnote">
-        <p>
-          Footnote definition 1<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-      <li id="fn:2" role="doc-endnote">
-        <p>
-          Footnote definition 2<a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-      <li id="fn:3" role="doc-endnote">
-        <p>
-          Footnote definition 3<a href="#fnref:3" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-      <li id="fn:4" role="doc-endnote">
-        <p>
-          Footnote definition 4<a href="#fnref:4" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-      <li id="fn:5" role="doc-endnote">
-        <p>
-          Footnote definition 5<a href="#fnref:5" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-      <li id="fn:6" role="doc-endnote">
-        <p>
-          Footnote definition 6<a href="#fnref:6" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-      <li id="fn:7" role="doc-endnote">
-        <p>
-          Footnote definition 7<a href="#fnref:7" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-      <li id="fn:8" role="doc-endnote">
-        <p>
-          Footnote definition 8<a href="#fnref:8" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-      <li id="fn:9" role="doc-endnote">
-        <p>
-          Footnote definition 9<a href="#fnref:9" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-      <li id="fn:10" role="doc-endnote">
-        <p>
-          Footnote definition 10<a href="#fnref:10" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-      <li id="fn:11" role="doc-endnote">
-        <p>
-          Footnote definition 11<a href="#fnref:11" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-      <li id="fn:12" role="doc-endnote">
-        <p>
-          Footnote definition 12<a href="#fnref:12" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
+            <p>Footnote definition 1 <a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
+          <li id="fn:2" role="doc-endnote">
+            <p>Footnote definition 2 <a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
+          <li id="fn:3" role="doc-endnote">
+            <p>Footnote definition 3 <a href="#fnref:3" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
+          <li id="fn:4" role="doc-endnote">
+            <p>Footnote definition 4 <a href="#fnref:4" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
+          <li id="fn:5" role="doc-endnote">
+            <p>Footnote definition 5 <a href="#fnref:5" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
+          <li id="fn:6" role="doc-endnote">
+            <p>Footnote definition 6 <a href="#fnref:6" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
+          <li id="fn:7" role="doc-endnote">
+            <p>Footnote definition 7 <a href="#fnref:7" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
+          <li id="fn:8" role="doc-endnote">
+            <p>Footnote definition 8 <a href="#fnref:8" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
+          <li id="fn:9" role="doc-endnote">
+            <p>Footnote definition 9 <a href="#fnref:9" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
+          <li id="fn:10" role="doc-endnote">
+            <p>Footnote definition 10 <a href="#fnref:10" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
+          <li id="fn:11" role="doc-endnote">
+            <p>Footnote definition 11 <a href="#fnref:11" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
+          <li id="fn:12" role="doc-endnote">
+            <p>Footnote definition 12 <a href="#fnref:12" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
         </ol>
       </div>
     )
@@ -1047,29 +1029,27 @@ Teston
     [^2]: Footnote definition two
   " do
     assert_html_output %(
+    <div class="legislative-list-wrapper">
       <ol class="legislative-list">
         <li>1. Item 1<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup> with a <a href="http://www.gov.uk">link</a>
-      </li>
+    </li>
         <li>2. Item 2</li>
         <li>3. Item 3</li>
       </ol>
+    </div>
 
-      <p>This is a paragraph with a footnote<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup></p>
+    <p>This is a paragraph with a footnote<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup></p>
 
-      <div class="footnotes" role="doc-endnotes">
-        <ol>
-          <li id="fn:1" role="doc-endnote">
-        <p>
-          Footnote definition one<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-      <li id="fn:2" role="doc-endnote">
-        <p>
-          Footnote definition two<a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-        </ol>
-      </div>
+    <div class="footnotes" role="doc-endnotes">
+      <ol>
+        <li id="fn:1" role="doc-endnote">
+          <p>Footnote definition one <a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+        </li>
+        <li id="fn:2" role="doc-endnote">
+          <p>Footnote definition two <a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+        </li>
+      </ol>
+    </div>
     )
   end
 
@@ -1084,28 +1064,26 @@ Teston
     [^2]: Footnote definition two with an external [link](http://www.google.com)
   " do
     assert_html_output %(
+    <div class="legislative-list-wrapper">
       <ol class="legislative-list">
         <li>1. Item 1<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup> with a <a href="http://www.gov.uk">link</a>
-      </li>
+    </li>
         <li>2. Item 2</li>
         <li>3. Item 3<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup>
-      </li>
+    </li>
       </ol>
+    </div>
 
-      <div class="footnotes" role="doc-endnotes">
-        <ol>
-          <li id="fn:1" role="doc-endnote">
-        <p>
-          Footnote definition one with a <a href="http://www.gov.uk">link</a> included<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-      <li id="fn:2" role="doc-endnote">
-        <p>
-          Footnote definition two with an external <a rel="external" href="http://www.google.com">link</a><a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-        </ol>
-      </div>
+    <div class="footnotes" role="doc-endnotes">
+      <ol>
+        <li id="fn:1" role="doc-endnote">
+          <p>Footnote definition one with a <a href="http://www.gov.uk">link</a> included <a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+        </li>
+        <li id="fn:2" role="doc-endnote">
+          <p>Footnote definition two with an external <a rel="external" href="http://www.google.com">link</a> <a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+        </li>
+      </ol>
+    </div>
     )
   end
 
@@ -1116,17 +1094,17 @@ Teston
     [^1]: footnote text
   " do
     assert_html_output %(
-      <p>1.  some text<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup>:</p>
+     <div class="legislative-list-wrapper">
+       <p>1.  some text<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup>:</p>
+     </div>
 
-      <div class="footnotes" role="doc-endnotes">
-        <ol>
-          <li id="fn:1" role="doc-endnote">
-        <p>
-          footnote text<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-        </ol>
-      </div>
+     <div class="footnotes" role="doc-endnotes">
+       <ol>
+         <li id="fn:1" role="doc-endnote">
+           <p>footnote text <a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+         </li>
+       </ol>
+     </div>
     )
   end
 
@@ -1137,15 +1115,15 @@ Teston
     [^1]: footnote text
     " do
       assert_html_output %(
-      <p>1.  some text<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup>: extra</p>
+      <div class="legislative-list-wrapper">
+        <p>1.  some text<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup>: extra</p>
+      </div>
 
       <div class="footnotes" role="doc-endnotes">
         <ol>
           <li id="fn:1" role="doc-endnote">
-        <p>
-          footnote text<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
+            <p>footnote text <a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
         </ol>
       </div>
     )
@@ -1166,32 +1144,28 @@ Teston
     *[class]: Testing HTML matching
   " do
     assert_html_output %(
-      <ol class="legislative-list">
-        <li>1. Item 1<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup> with an <abbr title="This is the acronym explanation">ACRONYM</abbr>
+      <div class="legislative-list-wrapper">
+        <ol class="legislative-list">
+          <li>1. Item 1<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup> with an <abbr title="This is the acronym explanation">ACRONYM</abbr>
       </li>
-        <li>2. Item 2<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup>
+          <li>2. Item 2<sup id="fnref:2" role="doc-noteref"><a href="#fn:2" class="footnote" rel="footnote">[footnote 2]</a></sup>
       </li>
-        <li>3. Item 3<sup id="fnref:3" role="doc-noteref"><a href="#fn:3" class="footnote" rel="footnote">[footnote 3]</a></sup>
+          <li>3. Item 3<sup id="fnref:3" role="doc-noteref"><a href="#fn:3" class="footnote" rel="footnote">[footnote 3]</a></sup>
       </li>
-      </ol>
+        </ol>
+      </div>
 
       <div class="footnotes" role="doc-endnotes">
         <ol>
           <li id="fn:1" role="doc-endnote">
-        <p>
-          Footnote definition one<a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-      <li id="fn:2" role="doc-endnote">
-        <p>
-          Footnote definition two with an <abbr title="This is the acronym explanation">ACRONYM</abbr><a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
-      <li id="fn:3" role="doc-endnote">
-        <p>
-          Footnote definition three with an acronym that matches an HTML tag <abbr title="Testing HTML matching">class</abbr><a href="#fnref:3" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a>
-        </p>
-      </li>
+            <p>Footnote definition one <a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
+          <li id="fn:2" role="doc-endnote">
+            <p>Footnote definition two with an <abbr title="This is the acronym explanation">ACRONYM</abbr> <a href="#fnref:2" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
+          <li id="fn:3" role="doc-endnote">
+            <p>Footnote definition three with an acronym that matches an HTML tag <abbr title="Testing HTML matching">class</abbr> <a href="#fnref:3" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
         </ol>
       </div>
     )
@@ -1218,9 +1192,11 @@ Teston
     assert_html_output %(
       <p>The quick brown fox</p>
 
-      <ol class="legislative-list">
-        <li>1. jumps over the lazy dog</li>
-      </ol>
+      <div class="legislative-list-wrapper">
+        <ol class="legislative-list">
+          <li>1. jumps over the lazy dog</li>
+        </ol>
+      </div>
     )
   end
 
@@ -1228,9 +1204,67 @@ Teston
     assert_html_output %(
       <p>This bit of text</p>
 
-      <ol class="legislative-list">
-        <li>1. should be turned into a list</li>
-      </ol>
+      <div class="legislative-list-wrapper">
+        <ol class="legislative-list">
+          <li>1. should be turned into a list</li>
+        </ol>
+      </div>
+    )
+  end
+
+  test_given_govspeak "
+    $LegislativeList
+    Welcome to the GOV.UK website
+    $EndLegislativeList
+
+    *[GOV.UK]: The official UK government website
+    *[website]: A collection of web pages, such as GOV.UK
+    " do
+    assert_html_output %(
+      <div class="legislative-list-wrapper">
+        <p>Welcome to the <abbr title="The official UK government website">GOV.UK</abbr> <abbr title="A collection of web pages, such as GOV.UK">website</abbr></p>
+      </div>
+    )
+  end
+
+  test_given_govspeak "
+    $LegislativeList
+    Please email <developer@digital.cabinet-office.GOV.UK>
+    $EndLegislativeList
+
+    *[GOV.UK]: The official UK government website
+  " do
+    assert_html_output %(
+      <div class="legislative-list-wrapper">
+        <p>Please email <a href="mailto:developer@digital.cabinet-office.GOV.UK">developer@digital.cabinet-office.<abbr title="The official UK government website">GOV.UK</abbr></a></p>
+      </div>
+    )
+  end
+
+  test_given_govspeak "
+    $LegislativeList
+    Welcome to the GOV.UK[^1]
+    $EndLegislativeList
+
+    [^1]: GOV.UK is the official UK government website
+
+    *[GOV.UK]: The official UK government website
+    *[website]: A collection of web pages, such as GOV.UK
+
+    *[GOV.UK]: The official UK government website
+    " do
+    assert_html_output %(
+      <div class="legislative-list-wrapper">
+        <p>Welcome to the <abbr title="The official UK government website">GOV.UK</abbr><sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">[footnote 1]</a></sup></p>
+      </div>
+
+      <div class="footnotes" role="doc-endnotes">
+        <ol>
+          <li id="fn:1" role="doc-endnote">
+            <p><abbr title="The official UK government website">GOV.UK</abbr> is the official UK government <abbr title="A collection of web pages, such as GOV.UK">website</abbr> <a href="#fnref:1" class="reversefootnote" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+          </li>
+        </ol>
+      </div>
     )
   end
 


### PR DESCRIPTION
https://trello.com/c/I15QapuL

### Parse call to action as part of the main conversion
Kramdown handles abbreviations and footnotes natively.

Call to action and legislative list are custom Govspeak components built as
extensions to Kramdown. These sections are parsed separately in preprocessing,
they are ignored in any subsequent parsing because Kramdown ignores HTML.

Because of this, we have added custom handling of abbreviations and footnotes
specifically for these components [1]. This custom implementation means that
abbreviations defined anywhere in the document will be applied to call to
action and legislative list components. Otherwise, only abbreviations defined
within these components would be applied.

This custom implementation has been shown to contain bugs through several
Zendesk tickets. The main issues reported are:

1. Acronyms are inserted into the produced HTML, even if undesirable. For
example, a link `<email@example.com>` with the acronym `*[email]: Electronic
mail is a method of transmitting and receiving messages` would produce
`<p>href="mailto:<abbr title="Electronic mail is a method of transmitting and
receiving messages">email</abbr>@example.com"<abbr title="Electronic mail is a
method of transmitting and receiving messages">email</abbr>@example.com</p>`
rather than the expected link.

2. Because the `add_acronym_alt_text` method runs through the text for each
acronym, acronyms can be inserted into other acronyms creating invalid HTML.

If we change tack, and instead allow Kramdown to parse these components as part
of the main conversion to HTML (instead of in preprocessing), Kramdown will
handle abbreviations and footnotes correctly, fixing both of these issues (as well
as some other undocumented issues). 

The call to action component requires a surrounding `div` with the
`call-to-action` class. Because Kramdown syntax is normally not processed inside
a HTML tag, we must toggle the `parse_block_html` option [2]. 

There is a small regression in that the `$CTA` block must be preceded by a
blank line (demonstrated in `test/govspeak_test.rb:428`), but this seems okay
as it's standard markdown.

Some of the tests can likely be removed as we are now testing the functionality
of the library, however, for now these represent that there are no
regressions.

[1]: https://github.com/alphagov/govspeak/pull/285
[2]: https://kramdown.gettalong.org/quickref.html#html-elements

### Parse legislative list as part of the main conversion
Kramdown handles abbreviations and footnotes natively.

Call to action and legislative list are custom Govspeak components built as
extensions to Kramdown. These sections are parsed separately in preprocessing,
they are ignored in any subsequent parsing because Kramdown ignores HTML.

Because of this, we have added custom handling of abbreviations and footnotes
specifically for these components [1]. This custom implementation means that
abbreviations defined anywhere in the document will be applied to call to
action and legislative list components. Otherwise, only abbreviations defined
within these components would be applied.

This custom implementation has been shown to contain bugs through several
Zendesk tickets. The main issues reported are:

1. Acronyms are inserted into the produced HTML, even if undesirable. For
example, a link `<email@example.com>` with the acronym `*[email]: Electronic
mail is a method of transmitting and receiving messages` would produce
`<p>href="mailto:<abbr title="Electronic mail is a method of transmitting and
receiving messages">email</abbr>@example.com"<abbr title="Electronic mail is a
method of transmitting and receiving messages">email</abbr>@example.com</p>`
rather than the expected link.

2. Because the `add_acronym_alt_text` method runs through the text for each
acronym, acronyms can be inserted into other acronyms creating invalid HTML.

If we change tack, and instead allow Kramdown to parse these components as part
of the main conversion to HTML (instead of in preprocessing), Kramdown will
handle abbreviations and footnotes correctly, fixing both of these issues (as
well as some other undocumented issues). 

The legislative list component currently works by overriding Kramdowns `list`
extension [2] and disabling ordered lists [3]. So that we can parse this
component as part of the main conversion, this applies two options:
`parse_block_html` [4], so that markdown inside the `legislative-list-wrapper`
`div` is parsed by Kramdown, and a new custom option of
`ordered_lists_disabled`, so that we can control flow inside our
`Parser::Govuk` class (subclass of the Kramdown parser). It is possible to
override `parse_list` instead of `parse_block_html`, but this means that the
outermost list will not be parsed (by the time `parse_list` is called the
outermost list is already being parsed)

The only difference between this new iteration of the legislative list and the
previous iteration, is that we now wrap the component in a
`legislative-list-wrapper` `div`. We could remove this in postprocessing, but
this requires additional modification of the Kramdown produced HTML which seems
unnecessary.

This also allows us to remove all remaining code which replicates the footnote
and acronym functions of Kramdown.

Some of the tests can likely be removed as we are now testing the functionality
of the library, however, for now these represent that there are no
regressions.

[1]: https://github.com/alphagov/govspeak/pull/285
[2]:
https://github.com/gettalong/kramdown/blob/bd678ecb59f70778fdb3b08bdcd39e2ab7379b45/lib/kramdown/parser/kramdown/list.rb#L54
[3]: https://github.com/alphagov/govspeak/pull/25
[4]: https://kramdown.gettalong.org/quickref.html#html-elements