### PR TITLE
Release 8.3.0

### DIFF
--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "8.2.1".freeze
+  VERSION = "8.3.0".freeze
 end


### PR DESCRIPTION
Release version 8.3.0 which includes the [fixes to abbreviations inside call to action and legislative list components.](https://github.com/alphagov/govspeak/pull/291)

---

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.


