### PR TITLE
Fix issues with block elements inside CTA and LegislativeList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.3.1
+
+* Bug fixes related to block elements in call to action and legislative list components ([#293](https://github.com/alphagov/govspeak/pull/293))
+
 ## 8.3.0
 
 * Various bug fixes related to abbreviations in call to action and legislative list components ([#291](https://github.com/alphagov/govspeak/pull/291))

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -278,9 +278,7 @@ module Govspeak
 
     extension("call-to-action", surrounded_by("$CTA")) do |body|
       <<~BODY
-        {::options parse_block_html=\"true\" /}
-        <div class="call-to-action">#{body}</div>
-        {::options parse_block_html=\"false\" /}
+        <div class="call-to-action" markdown="1">#{body}</div>
       BODY
     end
 
@@ -303,9 +301,9 @@ module Govspeak
       # The surrounding div is neccessary to control flow in `parse_block_html` and
       # maintain the same functionality as a previous version of this extension.
       <<~BODY
-        {::options parse_block_html=\"true\" ordered_lists_disabled=\"true\" /}
-        <div class="legislative-list-wrapper">#{body}</div>
-        {::options parse_block_html=\"false\" ordered_lists_disabled=\"false\" /}
+        {::options ordered_lists_disabled=\"true\" /}
+        <div class="legislative-list-wrapper" markdown="1">#{body}</div>
+        {::options ordered_lists_disabled=\"false\" /}
       BODY
     end
 

--- a/test/govspeak_images_test.rb
+++ b/test/govspeak_images_test.rb
@@ -4,13 +4,6 @@ require "govspeak_test_helper"
 class GovspeakImagesTest < Minitest::Test
   include GovspeakTestHelper
 
-  def build_image(attrs = {})
-    attrs[:alt_text] ||= "my alt"
-    attrs[:url] ||= "http://example.com/image.jpg"
-    attrs[:id] ||= "image-id"
-    attrs
-  end
-
   test "Image:image-id syntax renders an image in options[:images]" do
     given_govspeak "[Image:image-id]", images: [build_image] do
       assert_html_output(

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -683,6 +683,24 @@ Teston
     )
   end
 
+  test "CTA with image" do
+    given_govspeak "
+    $CTA
+    [Image:image-id]
+    $CTA
+
+    Some text
+    ", images: [build_image] do
+      assert_html_output %(
+      <div class="call-to-action">
+        <figure class="image embedded"><div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div></figure>
+      </div>
+
+      <p>Some text</p>
+    )
+    end
+  end
+
   test_given_govspeak "
     1. rod
     2. jane
@@ -1266,6 +1284,24 @@ Teston
         </ol>
       </div>
     )
+  end
+
+  test "LegislativeList with image" do
+    given_govspeak "
+    $LegislativeList
+    [Image:image-id]
+    $EndLegislativeList
+
+    Some text
+    ", images: [build_image] do
+      assert_html_output %(
+      <div class="legislative-list-wrapper">
+        <figure class="image embedded"><div class="img"><img src="http://example.com/image.jpg" alt="my alt"></div></figure>
+      </div>
+
+      <p>Some text</p>
+    )
+    end
   end
 
   test_given_govspeak "

--- a/test/govspeak_test_helper.rb
+++ b/test/govspeak_test_helper.rb
@@ -73,6 +73,13 @@ module GovspeakTestHelper
     coder.decode(html)
   end
 
+  def build_image(attrs = {})
+    attrs[:alt_text] ||= "my alt"
+    attrs[:url] ||= "http://example.com/image.jpg"
+    attrs[:id] ||= "image-id"
+    attrs
+  end
+
   module ClassMethods
     def test_given_govspeak(govspeak, options = {}, &block)
       test "Given #{govspeak}" do


### PR DESCRIPTION
https://trello.com/c/VyfTCVe1

In https://github.com/alphagov/govspeak/pull/291, we made a change to how the call to action and legislative list
components are parsed. This involved the use of the `parse_block_html` option,
which enables parsing in HTML blocks until it is toggled off.

Since this change, we have received Zendesk tickets regarding the use of the
image component inside a call to action. Because we toggle off the parsing of
HTML blocks entirely within call to actions, the HTML of the image is not
parsed correctly.

To fix this, we can enable parsing of the surrounding divs of the call to
action and legislative list components only. This means that any inner blocks
(such as the `figure` tag surrounding an image) are parsed using their default
mechanism [1].

[1]: https://kramdown.gettalong.org/syntax.html#html-blocks.

## Before
![image](https://github.com/alphagov/govspeak/assets/47089130/3044f4b3-ea31-49c9-8673-ebb6f27b3074)

## After
![image](https://github.com/alphagov/govspeak/assets/47089130/87fd4dc6-ac50-4b7b-9d70-addfbb0d13b4)

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.


