### PR TITLE
Fix single line formatting of call to action component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Fix single line formatting of call to action component ([#302](https://github.com/alphagov/govspeak/pull/302))
+
 ## 8.3.2
 
 * Various bug fixes related to legislative list components ([#298](https://github.com/alphagov/govspeak/pull/298))

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -277,7 +277,9 @@ module Govspeak
 
     extension("call-to-action", surrounded_by("$CTA")) do |body|
       <<~BODY
-        <div class="call-to-action" markdown="1">#{body}</div>
+        <div class="call-to-action" markdown="1">
+        #{body.strip}
+        </div>
       BODY
     end
 

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -426,6 +426,48 @@ Teston
   end
 
   test_given_govspeak "
+    $CTA Click here to start the program $CTA
+
+    Here is some text" do
+    assert_html_output %(
+      <div class="call-to-action">
+        <p>Click here to start the program</p>
+      </div>
+
+      <p>Here is some text</p>)
+  end
+
+  test_given_govspeak "
+    Some text
+
+    $CTA     Click there to start the program     $CTA
+
+    Here is some text" do
+    assert_html_output %(
+      <p>Some text</p>
+      <div class="call-to-action">
+        <p>Click there to start the program</p>
+      </div>
+
+      <p>Here is some text</p>)
+  end
+
+  test_given_govspeak "
+    Some text
+
+    $CTAClick anywhere to start the program$CTA
+
+    Here is some text" do
+    assert_html_output %(
+      <p>Some text</p>
+      <div class="call-to-action">
+        <p>Click anywhere to start the program</p>
+      </div>
+
+      <p>Here is some text</p>)
+  end
+
+  test_given_govspeak "
     Here is some text\n
 
     $CTA
@@ -453,7 +495,6 @@ Teston
     $CTA" do
     assert_html_output %(
         <div class="call-to-action">
-
           <p>This is a test:</p>
 
           <ol class="steps">


### PR DESCRIPTION
https://trello.com/c/iRNwQY9I

We use the default mechanism for parsing the call to action component so that
the parser handles abbreviations and footnotes within.

Since this change (#292) we have seen a regression where defining a call to
action on a single line does not work as expected (e.g., `$CTA Click here to
start the program $CTA`). The closing `div` is evaluated as markdown and the
call to action component therefore runs on until the next closing `div`.

This can be fixed by adding in some new lines between the div tags.


|Before recent changes (version 8.2.1)|Current (version 8.3.2)|This PR|
|-|-|-|
|<img width="999" alt="image" src="https://github.com/alphagov/govspeak/assets/47089130/28cba83d-34fb-4318-905a-8e21a2e65538">|<img width="954" alt="image" src="https://github.com/alphagov/govspeak/assets/47089130/f6b9a549-bada-469f-99f3-823b978cfb6c">|<img width="982" alt="image" src="https://github.com/alphagov/govspeak/assets/47089130/be02eaf7-9bb1-4b7e-a077-99e8d20dbac0">|
|<img width="999" alt="image" src="https://github.com/alphagov/govspeak/assets/47089130/407531b1-c8a1-4594-ab62-fa93b89072d3">|<img width="995" alt="image" src="https://github.com/alphagov/govspeak/assets/47089130/4d70c6cc-0f5a-46c8-8c67-a2d095c68b0a">|<img width="1000" alt="image" src="https://github.com/alphagov/govspeak/assets/47089130/addf58eb-40a1-4f83-8eb1-e15f790a22d8">|
|<img width="989" alt="image" src="https://github.com/alphagov/govspeak/assets/47089130/f216b405-a467-4a71-b014-89663be518b1">|<img width="998" alt="image" src="https://github.com/alphagov/govspeak/assets/47089130/3cf0ca80-8cdc-4fc3-b4d5-1c744b3fdea9">|<img width="1011" alt="image" src="https://github.com/alphagov/govspeak/assets/47089130/1f675d5d-95e5-4bd0-97b4-2211e843cc26">|
|<img width="999" alt="image" src="https://github.com/alphagov/govspeak/assets/47089130/141abeb6-8384-465b-b459-5dff3e3dbf11">|<img width="985" alt="image" src="https://github.com/alphagov/govspeak/assets/47089130/d1635c6b-b67e-44a4-a8d1-bb731aa98b16">|<img width="984" alt="image" src="https://github.com/alphagov/govspeak/assets/47089130/e689ccfb-d0c5-4a8c-b7e0-5d73b34b0067">|


---

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.


