### PR TITLE
Remove old PR template

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,9 +1,0 @@
-## What
-<!-- Description of the change being made -->
-<!-- Remember to add this to the CHANGELOG if applicable -->
-
-## Why
-<!-- What are the reasons behind this change being made? -->
-
-## Visual Changes
-<!-- If the change results in visual changes, show a before and after -->


### PR DESCRIPTION
This repo has two PR templates defined, so we get an amalgamation of both when raising a PR.

<img width="926" alt="Screenshot 2024-06-27 at 13 02 56" src="https://github.com/alphagov/govspeak/assets/6329861/536fbc35-4edb-4f3b-b76a-b8488da1f03b">

Removing the old one, as we don't appear to be using it or formatting PRs in that way anymore.

