### PR TITLE
Pin dependencies to patch/sub-patch version

### DIFF
--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -29,12 +29,12 @@ library for use in the UK Government Single Domain project'
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.require_paths = %w[lib]
 
-  s.add_dependency "actionview", ">= 6"
-  s.add_dependency "addressable", ">= 2.3.8", "< 3"
+  s.add_dependency "actionview", ">= 6", "< 7.1.3.5"
+  s.add_dependency "addressable", ">= 2.3.8", "< 2.8.8"
   s.add_dependency "govuk_publishing_components", ">= 35.1", "< 39.1.1"
   s.add_dependency "htmlentities", "~> 4"
-  s.add_dependency "i18n", ">= 0.7"
-  s.add_dependency "kramdown", ">= 2.3.1"
+  s.add_dependency "i18n", ">= 0.7", "< 1.14.6"
+  s.add_dependency "kramdown", ">= 2.3.1", "< 2.4.1"
   s.add_dependency "nokogiri", "~> 1.12"
   s.add_dependency "rinku", "~> 2.0"
   s.add_dependency "sanitize", "~> 6"


### PR DESCRIPTION
We found that upgrades to packages whose versions were specified with `>=` with no upper bound were not being properly managed by Dependabot. A test failure caused by an upgrade to `govuk_publishing_components` for a version released on 11 June was only surfaced when Dependabot opened a PR to upgrade rubocop-govuk on 26 June. The test failure was minor, but it's conceivable that there could be a more breaking change that we wouldn't be aware of until a separate pinned dependency has an available upgrade. This might cause the gem not to work as expected if included in apps with untested versions of dependencies

We might want to apply similar changes to other GOV.UK gems

---

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.


