### PR TITLE
Support acronyms within example and address blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Drop support for Ruby 3.0. The minimum required Ruby version is now 3.1.4.
 * Add support for Ruby 3.3.
+* Allow acronyms within example blocks.
 
 ## 8.3.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Drop support for Ruby 3.0. The minimum required Ruby version is now 3.1.4.
 * Add support for Ruby 3.3.
 * Allow acronyms within example blocks.
+* Allow tables within example blocks.
 
 ## 8.3.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add support for Ruby 3.3.
 * Allow acronyms within example blocks.
 * Allow tables within example blocks.
+* Allow acronyms within address blocks.
 
 ## 8.3.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 8.4.0
 
 * Drop support for Ruby 3.0. The minimum required Ruby version is now 3.1.4.
 * Add support for Ruby 3.3.

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -302,7 +302,7 @@ module Govspeak
     end
 
     extension("address", surrounded_by("$A")) do |body|
-      %(\n<div class="address"><div class="adr org fn"><p>\n#{body.sub("\n", '').gsub("\n", '<br />')}\n</p></div></div>\n)
+      %(\n<div class="address"><div class="adr org fn"><p markdown="1">\n#{body.sub("\n", '').gsub("\n", '<br />')}\n</p></div></div>\n)
     end
 
     extension("legislative list", /#{NEW_PARAGRAPH_LOOKBEHIND}\$LegislativeList\s*$(.*?)\$EndLegislativeList/m) do |body|

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -296,7 +296,7 @@ module Govspeak
     extension("example", surrounded_by("$E")) do |body|
       <<~BODY
         <div class="example" markdown="1">
-          #{body.strip}
+          #{body.strip.gsub(/\A^\|/, "\n|").gsub(/\|$\Z/, "|\n")}
         </div>
       BODY
     end

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -292,7 +292,14 @@ module Govspeak
     wrap_with_div("place", "$P", Govspeak::Document)
     wrap_with_div("information", "$I", Govspeak::Document)
     wrap_with_div("additional-information", "$AI")
-    wrap_with_div("example", "$E", Govspeak::Document)
+
+    extension("example", surrounded_by("$E")) do |body|
+      <<~BODY
+        <div class="example" markdown="1">
+          #{body.strip}
+        </div>
+      BODY
+    end
 
     extension("address", surrounded_by("$A")) do |body|
       %(\n<div class="address"><div class="adr org fn"><p>\n#{body.sub("\n", '').gsub("\n", '<br />')}\n</p></div></div>\n)

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "8.3.4".freeze
+  VERSION = "8.4.0".freeze
 end

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -1248,6 +1248,20 @@ Teston
     end
 
   test_given_govspeak "
+    $E
+    This is an ACRONYM.
+    $E
+
+    *[ACRONYM]: This is the acronym explanation
+  " do
+    assert_html_output %(
+      <div class="example">
+        <p>This is an <abbr title="This is the acronym explanation">ACRONYM</abbr>.</p>
+      </div>
+    )
+  end
+
+  test_given_govspeak "
     $LegislativeList
     * 1. Item 1[^1] with an ACRONYM
     * 2. Item 2[^2]

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -394,6 +394,19 @@ Teston
   end
 
   test_given_govspeak "
+    $A
+    street with ACRONYM
+    road
+    $A
+
+    *[ACRONYM]: This is the acronym explanation" do
+    assert_html_output %(
+      <div class="address"><div class="adr org fn"><p>
+      street with <abbr title="This is the acronym explanation">ACRONYM</abbr><br>road<br>
+      </p></div></div>)
+  end
+
+  test_given_govspeak "
     $P
     $I
     help

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -1262,6 +1262,33 @@ Teston
   end
 
   test_given_govspeak "
+    $E
+    |Heading 1|Heading 2|
+    |-|-|
+    |information|more information|
+    $E" do
+    assert_html_output %(
+    <div class="example">
+
+    <table>
+      <thead>
+        <tr>
+          <th scope="col">Heading 1</th>
+          <th scope="col">Heading 2</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>information</td>
+          <td>more information</td>
+        </tr>
+      </tbody>
+    </table>
+
+  </div>)
+  end
+
+  test_given_govspeak "
     $LegislativeList
     * 1. Item 1[^1] with an ACRONYM
     * 2. Item 2[^2]


### PR DESCRIPTION
Fixes an issue where acronyms are not correctly marked up when within example or address blocks.

[Trello card](https://trello.com/c/Eq8xjQV7)