### PR TITLE
Ignore embed codes when argument is blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 8.5.1
+
+* Rename embed-related code to `content block`
+* Do not attempt to parse embed codes if `content_blocks` option is missing
+
 ### 8.5.0
 
 * Support embeds in Govspeak

--- a/README.md
+++ b/README.md
@@ -610,7 +610,7 @@ will output
 
 ### Content blocks
 
-Authors can embed different types of [supported content](https://github.com/alphagov/govspeak/blob/main/lib/govspeak/embedded_content.rb#L3) created by the Content Block Manager
+Authors can embed different types of [supported content](https://github.com/alphagov/govspeak/blob/main/lib/govspeak/content_block.rb#L3) created by the Content Block Manager
 
 ```
 {{embed:content_block_email_address:d308f561-e5ee-45b5-90b2-3ac36a23fad9}}
@@ -620,7 +620,7 @@ with options provided
 
 ```
 {
-  embeds: [
+  content_blocks: [
     {
       content_id: "d308f561-e5ee-45b5-90b2-3ac36a23fad9",
       title: "Government Digital Service",

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -14,14 +14,14 @@ require "govspeak/structured_header_extractor"
 require "govspeak/html_validator"
 require "govspeak/html_sanitizer"
 require "govspeak/blockquote_extra_quote_remover"
-require "govspeak/embed_extractor"
-require "govspeak/embedded_content"
+require "govspeak/content_block_extractor"
+require "govspeak/content_block"
 require "govspeak/post_processor"
 require "govspeak/link_extractor"
 require "govspeak/template_renderer"
 require "govspeak/presenters/attachment_presenter"
 require "govspeak/presenters/contact_presenter"
-require "govspeak/presenters/embed_presenter"
+require "govspeak/presenters/content_block_presenter"
 require "govspeak/presenters/h_card_presenter"
 require "govspeak/presenters/image_presenter"
 require "govspeak/presenters/attachment_image_presenter"
@@ -40,7 +40,7 @@ module Govspeak
     @extensions = []
 
     attr_accessor :images
-    attr_reader :attachments, :contacts, :links, :locale, :embeds
+    attr_reader :attachments, :contacts, :links, :locale, :content_blocks
 
     def self.to_html(source, options = {})
       new(source, options).to_html
@@ -60,7 +60,7 @@ module Govspeak
       @attachments = Array.wrap(options.delete(:attachments))
       @links = Array.wrap(options.delete(:links))
       @contacts = Array.wrap(options.delete(:contacts))
-      @embeds = Array.wrap(options.delete(:embeds))
+      @content_blocks = Array.wrap(options.delete(:content_blocks))
       @locale = options.fetch(:locale, "en")
       @options = { input: PARSER_CLASS_NAME,
                    sanitize: true,
@@ -259,11 +259,11 @@ module Govspeak
       render_image(AttachmentImagePresenter.new(attachment))
     end
 
-    extension("embeds", Govspeak::EmbeddedContent::EMBED_REGEX) do |_embed_code, _document_type, content_id|
-      embed = embeds.detect { |e| e[:content_id] == content_id }
+    extension("content blocks", Govspeak::ContentBlock::EMBED_REGEX) do |_embed_code, _document_type, content_id|
+      embed = content_blocks.detect { |e| e[:content_id] == content_id }
       next "" unless embed
 
-      EmbedPresenter.new(embed).render
+      ContentBlockPresenter.new(embed).render
     end
 
     # As of version 1.12.0 of Kramdown the block elements (div & figcaption)

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -259,7 +259,9 @@ module Govspeak
       render_image(AttachmentImagePresenter.new(attachment))
     end
 
-    extension("content blocks", Govspeak::ContentBlock::EMBED_REGEX) do |_embed_code, _document_type, content_id|
+    extension("content blocks", Govspeak::ContentBlock::EMBED_REGEX) do |embed_code, _document_type, content_id|
+      next embed_code if content_blocks.empty?
+
       embed = content_blocks.detect { |e| e[:content_id] == content_id }
       next "" unless embed
 

--- a/lib/govspeak/content_block.rb
+++ b/lib/govspeak/content_block.rb
@@ -1,5 +1,5 @@
 module Govspeak
-  class EmbeddedContent
+  class ContentBlock
     SUPPORTED_DOCUMENT_TYPES = %w[contact content_block_email_address].freeze
     UUID_REGEX = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/
     EMBED_REGEX = /({{embed:(#{SUPPORTED_DOCUMENT_TYPES.join('|')}):#{UUID_REGEX}}})/

--- a/lib/govspeak/content_block_extractor.rb
+++ b/lib/govspeak/content_block_extractor.rb
@@ -1,12 +1,12 @@
 module Govspeak
-  class EmbedExtractor
+  class ContentBlockExtractor
     def initialize(document)
       @document = document
     end
 
     def content_references
-      @content_references ||= @document.scan(EmbeddedContent::EMBED_REGEX).map { |match|
-        EmbeddedContent.new(document_type: match[1], content_id: match[2], embed_code: match[0])
+      @content_references ||= @document.scan(ContentBlock::EMBED_REGEX).map { |match|
+        ContentBlock.new(document_type: match[1], content_id: match[2], embed_code: match[0])
       }.uniq
     end
 

--- a/lib/govspeak/presenters/content_block_presenter.rb
+++ b/lib/govspeak/presenters/content_block_presenter.rb
@@ -2,7 +2,7 @@ require "action_view"
 require "htmlentities"
 
 module Govspeak
-  class EmbedPresenter
+  class ContentBlockPresenter
     include ActionView::Helpers::TagHelper
 
     attr_reader :embed

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "8.5.0".freeze
+  VERSION = "8.5.1".freeze
 end

--- a/test/content_block_extractor_test.rb
+++ b/test/content_block_extractor_test.rb
@@ -1,10 +1,10 @@
 require "test_helper"
 
-class EmbedExtractorTest < Minitest::Test
+class ContentBlockExtractorTest < Minitest::Test
   extend Minitest::Spec::DSL
 
-  describe "EmbedExtractor" do
-    subject { Govspeak::EmbedExtractor.new(document) }
+  describe "ContentBlockExtractor" do
+    subject { Govspeak::ContentBlockExtractor.new(document) }
 
     describe "when there is no embedded content" do
       let(:document) { "foo" }

--- a/test/govspeak_content_blocks_test.rb
+++ b/test/govspeak_content_blocks_test.rb
@@ -42,12 +42,26 @@ class GovspeakContentBlocksTest < Minitest::Test
     assert_equal compress_html(expected), compress_html(rendered)
   end
 
-  it "ignores missing embeds" do
+  it "removes embed code if a content block cannot be found" do
+    content_block = {
+      content_id: SecureRandom.uuid,
+      document_type: "contact",
+      title: "foo",
+    }
+
     govspeak = "{{embed:contact:#{content_id}}}"
 
-    rendered = Govspeak::Document.new(govspeak, content_blocks: []).to_html
+    rendered = Govspeak::Document.new(govspeak, content_blocks: [content_block]).to_html
 
     assert_equal compress_html(""), compress_html(rendered)
+  end
+
+  it "retains an embed code if content_blocks are not specified" do
+    govspeak = "{{embed:contact:#{content_id}}}"
+
+    rendered = Govspeak::Document.new(govspeak).to_html
+
+    assert_equal compress_html("<p>#{govspeak}</p>"), compress_html(rendered)
   end
 
   it "supports multiple embeds" do

--- a/test/govspeak_content_blocks_test.rb
+++ b/test/govspeak_content_blocks_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class GovspeakEmbedsTest < Minitest::Test
+class GovspeakContentBlocksTest < Minitest::Test
   extend Minitest::Spec::DSL
 
   def compress_html(html)
@@ -10,7 +10,7 @@ class GovspeakEmbedsTest < Minitest::Test
   let(:content_id) { SecureRandom.uuid }
 
   it "renders an email address when present in options[:embeds]" do
-    embed = {
+    content_block = {
       content_id:,
       document_type: "content_block_email_address",
       title: "foo",
@@ -20,24 +20,24 @@ class GovspeakEmbedsTest < Minitest::Test
     }
     govspeak = "{{embed:content_block_email_address:#{content_id}}}"
 
-    rendered = Govspeak::Document.new(govspeak, embeds: [embed]).to_html
+    rendered = Govspeak::Document.new(govspeak, content_blocks: [content_block]).to_html
 
-    expected = "<p><span class=\"embed embed-content_block_email_address\" id=\"embed_#{content_id}\">#{embed[:details][:email_address]}</span></p>"
+    expected = "<p><span class=\"embed embed-content_block_email_address\" id=\"embed_#{content_id}\">#{content_block[:details][:email_address]}</span></p>"
 
     assert_equal compress_html(expected), compress_html(rendered)
   end
 
   it "renders the title when the document type is a contact" do
-    embed = {
+    content_block = {
       content_id:,
       document_type: "contact",
       title: "foo",
     }
     govspeak = "{{embed:contact:#{content_id}}}"
 
-    rendered = Govspeak::Document.new(govspeak, embeds: [embed]).to_html
+    rendered = Govspeak::Document.new(govspeak, content_blocks: [content_block]).to_html
 
-    expected = "<p><span class=\"embed embed-contact\" id=\"embed_#{content_id}\">#{embed[:title]}</span></p>"
+    expected = "<p><span class=\"embed embed-contact\" id=\"embed_#{content_id}\">#{content_block[:title]}</span></p>"
 
     assert_equal compress_html(expected), compress_html(rendered)
   end
@@ -45,13 +45,13 @@ class GovspeakEmbedsTest < Minitest::Test
   it "ignores missing embeds" do
     govspeak = "{{embed:contact:#{content_id}}}"
 
-    rendered = Govspeak::Document.new(govspeak, embeds: []).to_html
+    rendered = Govspeak::Document.new(govspeak, content_blocks: []).to_html
 
     assert_equal compress_html(""), compress_html(rendered)
   end
 
   it "supports multiple embeds" do
-    embeds = [
+    content_blocks = [
       {
         content_id: SecureRandom.uuid,
         document_type: "contact",
@@ -67,16 +67,16 @@ class GovspeakEmbedsTest < Minitest::Test
       },
     ]
 
-    govspeak = %(Here is a contact: {{embed:contact:#{embeds[0][:content_id]}}}
+    govspeak = %(Here is a contact: {{embed:contact:#{content_blocks[0][:content_id]}}}
 
-Here is an email address: {{embed:content_block_email_address:#{embeds[1][:content_id]}}}
+Here is an email address: {{embed:content_block_email_address:#{content_blocks[1][:content_id]}}}
     )
 
-    rendered = Govspeak::Document.new(govspeak, embeds:).to_html
+    rendered = Govspeak::Document.new(govspeak, content_blocks:).to_html
 
     expected = """
-      <p>Here is a contact: <span class=\"embed embed-contact\" id=\"embed_#{embeds[0][:content_id]}\">#{embeds[0][:title]}</span></p>
-      <p>Here is an email address: <span class=\"embed embed-content_block_email_address\" id=\"embed_#{embeds[1][:content_id]}\">#{embeds[1][:details][:email_address]}</span></p>
+      <p>Here is a contact: <span class=\"embed embed-contact\" id=\"embed_#{content_blocks[0][:content_id]}\">#{content_blocks[0][:title]}</span></p>
+      <p>Here is an email address: <span class=\"embed embed-content_block_email_address\" id=\"embed_#{content_blocks[1][:content_id]}\">#{content_blocks[1][:details][:email_address]}</span></p>
     """
 
     assert_equal compress_html(expected), compress_html(rendered)


### PR DESCRIPTION
After pushing out https://github.com/alphagov/govspeak/pull/355, I realised that there are some circumstances (such as in Whitehall), where Govspeak is rendered before sending to the Publishing API. This results in embed code being stripped out before making its way to the Publishing API.

Rather than yanking the version, or reverting the code, I've changed the logic to return the embed code, rather than returning an empty string if the `content_blocks` argument is blank.

I've also renamed some of the content block related code to be more expressive of what is being embedded (there are other types of embeds elsewhere). This could be considered a breaking change, but considering I'm the only person using this code, I think it's fine.

It might be prudent to yank version `8.5.0` once this is fully rolled out though.