### PR TITLE
Remove Advisory component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Remove Advisory component ([#357](https://github.com/alphagov/govspeak/pull/357))
+
 ## 8.8.3
 
 * Update dependencies (actionview < 8.0.2, sanitize < 8, rubocop-govuk = 5.0.7) 

--- a/README.md
+++ b/README.md
@@ -81,18 +81,6 @@ creates an example box
 
 ## Highlights
 
-### Advisory (DEPRECATED: marked for removal. Use 'Information callouts' instead.)
-
-    @This is a very important message or warning@
-
-highlights the enclosed text in yellow
-
-```html
-<h3 role="note" aria-label="Important" class="advisory">
-  <span>This is a very important message or warning</span>
-</h3>
-```
-
 ### Answer (DEPRECATED: marked for removal)
 
     {::highlight-answer}

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -201,10 +201,6 @@ module Govspeak
 #{Govspeak::Document.new(body.strip).to_html}</div>\n)
     end
 
-    extension("important", surrounded_by("@")) do |body|
-      %(\n\n<div role="note" aria-label="Important" class="advisory">#{insert_strong_inside_p(body)}</div>\n)
-    end
-
     extension("helpful", surrounded_by("%")) do |body|
       %(\n\n<div role="note" aria-label="Warning" class="application-notice help-notice">\n#{Govspeak::Document.new(body.strip).to_html}</div>\n)
     end

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -209,27 +209,6 @@ Teston
     assert_text_output "I am very informational"
   end
 
-  test_given_govspeak "@ I am very important @" do
-    assert_html_output %(
-      <div role="note" aria-label="Important" class="advisory">
-      <p><strong>I am very important</strong></p>
-      </div>)
-    assert_text_output "I am very important"
-  end
-
-  test_given_govspeak "
-    The following is very important
-    @ I am very important @
-    " do
-    assert_html_output %(
-      <p>The following is very important</p>
-
-      <div role="note" aria-label="Important" class="advisory">
-      <p><strong>I am very important</strong></p>
-      </div>)
-    assert_text_output "The following is very important I am very important"
-  end
-
   test_given_govspeak "% I am very helpful %" do
     assert_html_output %(
       <div role="note" aria-label="Warning" class="application-notice help-notice">
@@ -1525,14 +1504,6 @@ Teston
       </div>
       </div>
       '
-  end
-
-  test_given_govspeak "@ Message with [a link](http://foo.bar/)@" do
-    assert_html_output %(
-      <div role="note" aria-label="Important" class="advisory">
-      <p><strong>Message with <a rel="external" href="http://foo.bar/">a link</a></strong></p>
-      </div>
-      )
   end
 
   test "sanitize source input by default" do


### PR DESCRIPTION
The advisory component has been earmarked for removal. It does not pull in styles from the design system and so has to be manually updated if it needs changing.
Its uses will be replaced with [information callouts](https://github.com/alphagov/govspeak?tab=readme-ov-file#information-callouts).

Trello card: https://trello.com/c/Z26fvy04/2957-work-out-how-to-retire-advisory-from-govspeak-gem

