### PR TITLE
Allow data attributes in span tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 8.6.1
+## 8.7.0
+
+* Allow data attributes in spans ([#364](https://github.com/alphagov/govspeak/pull/364))
+
+## 8.6.1
 
 * Update dependencies
 

--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -56,6 +56,7 @@ class Govspeak::HtmlSanitizer
         "svg" => %w[xmlns width height viewbox focusable],
         "path" => %w[fill d],
         "div" => [:data],
+        "span" => [:data],
         # The style attributes are permitted here just for the ones Kramdown for table alignment
         # we replace them in a post processor.
         "th" => Sanitize::Config::RELAXED[:attributes]["th"] + %w[style],

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "8.6.1".freeze
+  VERSION = "8.7.0".freeze
 end

--- a/test/html_sanitizer_test.rb
+++ b/test/html_sanitizer_test.rb
@@ -63,6 +63,15 @@ class HtmlSanitizerTest < Minitest::Test
     )
   end
 
+  test "allow data attributes on spans" do
+    html = "<span data-module='toggle' data-ecommerce-path='/' data-track-category='someSpan'>Test Span</span>"
+
+    assert_equal(
+      "<span data-module=\"toggle\" data-ecommerce-path=\"/\" data-track-category=\"someSpan\">Test Span</span>",
+      Govspeak::HtmlSanitizer.new(html).sanitize,
+    )
+  end
+
   test "allows images on whitelisted domains" do
     html = "<img src='http://allowed.com/image.jgp'>"
     sanitized_html = Govspeak::HtmlSanitizer.new(html, allowed_image_hosts: ["allowed.com"]).sanitize


### PR DESCRIPTION
The work we’re doing in Content Modelling means we will be rendering content blocks within span tags with data attributes, which will make identifying content blocks easier. As we may be re-presenting content block embeds to Govspeak, we need to ensure that these tags don’t get stripped out, so we need to add `data-*` attributes to the allowlist for span tags.


