### PR TITLE
Strip trailing space from lines in address blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Strip trailing backslashes from the lines of an address
 * When replacing line breaks with "&lt;br&gt;"s in the parsing of address blocks,
 replace the whole "\r\n" line break and not just the "\n" character
+* Only strip a leading line break from an address block, not just any old first
+occurrence of a line break
 
 ## 8.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 replace the whole "\r\n" line break and not just the "\n" character
 * Only strip a leading line break from an address block, not just any old first
 occurrence of a line break
+* Strip trailing whitespace from the lines of an address
 
 ## 8.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+* Strip trailing backslashes from the lines of an address
+* When replacing line breaks with "&lt;br&gt;"s in the parsing of address blocks,
+replace the whole "\r\n" line break and not just the "\n" character
+
 ## 8.7.0
 
 * Allow data attributes in spans ([#364](https://github.com/alphagov/govspeak/pull/364))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
-## Unreleased
+## 8.8.0
 
-* Strip trailing backslashes from the lines of an address
+* Strip trailing backslashes from the lines of an address ([#371](https://github.com/alphagov/govspeak/pull/371))
 * When replacing line breaks with "&lt;br&gt;"s in the parsing of address blocks,
-replace the whole "\r\n" line break and not just the "\n" character
+replace the whole "\r\n" line break and not just the "\n" character ([#371](https://github.com/alphagov/govspeak/pull/371))
 * Only strip a leading line break from an address block, not just any old first
-occurrence of a line break
-* Strip trailing whitespace from the lines of an address
+occurrence of a line break ([#371](https://github.com/alphagov/govspeak/pull/371))
+* Strip trailing whitespace from the lines of an address ([#371](https://github.com/alphagov/govspeak/pull/371))
 
 ## 8.7.0
 

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -305,7 +305,7 @@ module Govspeak
       <<~BODY
 
         <div class="address"><div class="adr org fn"><p markdown="1">
-        #{body.sub(/\r?\n/, '').gsub(/\\*\r?\n/, '<br />')}
+        #{body.lstrip.gsub(/\\*\r?\n/, '<br />')}
         </p></div></div>
       BODY
     end

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -305,7 +305,7 @@ module Govspeak
       <<~BODY
 
         <div class="address"><div class="adr org fn"><p markdown="1">
-        #{body.sub("\n", '').gsub("\n", '<br />')}
+        #{body.sub(/\r?\n/, '').gsub(/\\*\r?\n/, '<br />')}
         </p></div></div>
       BODY
     end

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -302,7 +302,12 @@ module Govspeak
     end
 
     extension("address", surrounded_by("$A")) do |body|
-      %(\n<div class="address"><div class="adr org fn"><p markdown="1">\n#{body.sub("\n", '').gsub("\n", '<br />')}\n</p></div></div>\n)
+      <<~BODY
+
+        <div class="address"><div class="adr org fn"><p markdown="1">
+        #{body.sub("\n", '').gsub("\n", '<br />')}
+        </p></div></div>
+      BODY
     end
 
     extension("legislative list", /#{NEW_PARAGRAPH_LOOKBEHIND}\$LegislativeList\s*$(.*?)\$EndLegislativeList/m) do |body|

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -305,7 +305,7 @@ module Govspeak
       <<~BODY
 
         <div class="address"><div class="adr org fn"><p markdown="1">
-        #{body.lstrip.gsub(/\\*\r?\n/, '<br />')}
+        #{body.lstrip.sub(/[\s\\]*\z/, '').gsub(/[ \\]*\r?\n/, '<br />')}
         </p></div></div>
       BODY
     end

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "8.7.0".freeze
+  VERSION = "8.8.0".freeze
 end

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -106,26 +106,40 @@ Testcase Cliffs
 Teston
 0123 456 7890 $A    )
     doc = Govspeak::Document.new(input)
-    assert_equal %(\n<div class="address"><div class="adr org fn"><p>\n123 Test Street<br>Testcase Cliffs<br>Teston<br>0123 456 7890 \n</p></div></div>\n), doc.to_html
+    assert_equal %(\n<div class="address"><div class="adr org fn"><p>\n123 Test Street<br>Testcase Cliffs<br>Teston<br>0123 456 7890\n</p></div></div>\n), doc.to_html
   end
 
   test "newlines in address block content are replaced with <br>s" do
     input = %($A\n123 Test Street\nTestcase Cliffs\nTeston\n0123 456 7890\n$A)
     doc = Govspeak::Document.new(input)
-    assert_equal %(\n<div class="address"><div class="adr org fn"><p>\n123 Test Street<br>Testcase Cliffs<br>Teston<br>0123 456 7890<br>\n</p></div></div>\n), doc.to_html
+    assert_equal %(\n<div class="address"><div class="adr org fn"><p>\n123 Test Street<br>Testcase Cliffs<br>Teston<br>0123 456 7890\n</p></div></div>\n), doc.to_html
   end
 
   test "combined return-and-newlines in address block content are replaced with <br>s" do
     input = %($A\r\n123 Test Street\r\nTestcase Cliffs\r\nTeston\r\n0123 456 7890\r\n$A)
     doc = Govspeak::Document.new(input)
-    assert_equal %(\n<div class="address"><div class="adr org fn"><p>\n123 Test Street<br>Testcase Cliffs<br>Teston<br>0123 456 7890<br>\n</p></div></div>\n), doc.to_html
+    assert_equal %(\n<div class="address"><div class="adr org fn"><p>\n123 Test Street<br>Testcase Cliffs<br>Teston<br>0123 456 7890\n</p></div></div>\n), doc.to_html
   end
 
   test "trailing backslashes are stripped from address block content" do
     # two trailing backslashes would normally be converted into a line break by Kramdown
     input = %($A\r\n123 Test Street\\\r\nTestcase Cliffs\\\nTeston\\\\\r\n0123 456 7890\\\\\n$A)
     doc = Govspeak::Document.new(input)
-    assert_equal %(\n<div class="address"><div class="adr org fn"><p>\n123 Test Street<br>Testcase Cliffs<br>Teston<br>0123 456 7890<br>\n</p></div></div>\n), doc.to_html
+    assert_equal %(\n<div class="address"><div class="adr org fn"><p>\n123 Test Street<br>Testcase Cliffs<br>Teston<br>0123 456 7890\n</p></div></div>\n), doc.to_html
+  end
+
+  test "trailing spaces are stripped from address block content" do
+    # two trailing spaces would normally be converted into a line break by Kramdown
+    input = %($A\r\n123 Test Street \r\nTestcase Cliffs  \nTeston   \r\n0123 456 7890    \n$A)
+    doc = Govspeak::Document.new(input)
+    assert_equal %(\n<div class="address"><div class="adr org fn"><p>\n123 Test Street<br>Testcase Cliffs<br>Teston<br>0123 456 7890\n</p></div></div>\n), doc.to_html
+  end
+
+  test "trailing backslashes and spaces are stripped from address block content" do
+    # two trailing backslashes or two trailing spaces would normally be converted into a line break by Kramdown
+    input = %($A\r\n123 Test Street  \\\r\nTestcase Cliffs\\  \nTeston\\\\  \r\n0123 456 7890  \\\\\n$A)
+    doc = Govspeak::Document.new(input)
+    assert_equal %(\n<div class="address"><div class="adr org fn"><p>\n123 Test Street<br>Testcase Cliffs<br>Teston<br>0123 456 7890\n</p></div></div>\n), doc.to_html
   end
 
   test "should convert barchart" do
@@ -160,7 +174,7 @@ Testcase Cliffs
 Teston
 0123 456 7890 $A)
     doc = Govspeak::Document.new(input)
-    assert_equal %(<p>Paragraph1</p>\n\n<div class="address"><div class="adr org fn"><p>\n123 Test Street<br>Testcase Cliffs<br>Teston<br>0123 456 7890 \n</p></div></div>\n), doc.to_html
+    assert_equal %(<p>Paragraph1</p>\n\n<div class="address"><div class="adr org fn"><p>\n123 Test Street<br>Testcase Cliffs<br>Teston<br>0123 456 7890\n</p></div></div>\n), doc.to_html
   end
 
   test_given_govspeak("^ I am very informational ^") do
@@ -407,7 +421,7 @@ Teston
     $A" do
     assert_html_output %(
       <div class="address"><div class="adr org fn"><p>
-      street<br>road<br>
+      street<br>road
       </p></div></div>)
     assert_text_output "street road"
   end
@@ -421,7 +435,7 @@ Teston
     *[ACRONYM]: This is the acronym explanation" do
     assert_html_output %(
       <div class="address"><div class="adr org fn"><p>
-      street with <abbr title="This is the acronym explanation">ACRONYM</abbr><br>road<br>
+      street with <abbr title="This is the acronym explanation">ACRONYM</abbr><br>road
       </p></div></div>)
   end
 

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -109,6 +109,25 @@ Teston
     assert_equal %(\n<div class="address"><div class="adr org fn"><p>\n123 Test Street<br>Testcase Cliffs<br>Teston<br>0123 456 7890 \n</p></div></div>\n), doc.to_html
   end
 
+  test "newlines in address block content are replaced with <br>s" do
+    input = %($A\n123 Test Street\nTestcase Cliffs\nTeston\n0123 456 7890\n$A)
+    doc = Govspeak::Document.new(input)
+    assert_equal %(\n<div class="address"><div class="adr org fn"><p>\n123 Test Street<br>Testcase Cliffs<br>Teston<br>0123 456 7890<br>\n</p></div></div>\n), doc.to_html
+  end
+
+  test "combined return-and-newlines in address block content are replaced with <br>s" do
+    input = %($A\r\n123 Test Street\r\nTestcase Cliffs\r\nTeston\r\n0123 456 7890\r\n$A)
+    doc = Govspeak::Document.new(input)
+    assert_equal %(\n<div class="address"><div class="adr org fn"><p>\n123 Test Street<br>Testcase Cliffs<br>Teston<br>0123 456 7890<br>\n</p></div></div>\n), doc.to_html
+  end
+
+  test "trailing backslashes are stripped from address block content" do
+    # two trailing backslashes would normally be converted into a line break by Kramdown
+    input = %($A\r\n123 Test Street\\\r\nTestcase Cliffs\\\nTeston\\\\\r\n0123 456 7890\\\\\n$A)
+    doc = Govspeak::Document.new(input)
+    assert_equal %(\n<div class="address"><div class="adr org fn"><p>\n123 Test Street<br>Testcase Cliffs<br>Teston<br>0123 456 7890<br>\n</p></div></div>\n), doc.to_html
+  end
+
   test "should convert barchart" do
     input = <<~GOVSPEAK
       |col|


### PR DESCRIPTION
There's a feature in the Kramdown parser (i.e. the library that the
Govspeak parser is built on top of) where two or more trailing
spaces at the end of a line of Govspeak will be converted into an
additional line break in the output HTML.

Until recently, the contents of address blocks weren't "reparsed" in the
Govspeak parser, meaning that they weren't subject to this Kramdown
feature. But the Govspeak parser code was recently updated and the
contents of address blocks are now reparsed. This has resulted in
unintentional additional line spacing being made visible in some
addresses that have been rendered by this new version Govspeak.

A typical example of the issue looks like:
```
| Name
|
| Street
|
| Town
|
| Postcode
|
```

where it would've previously looked like:
```
| Name
| Street
| Town
| Postcode
```

By stripping the trailing space from Govspeak lines within address
blocks, we effectively disable the Kramdown feature and prevent
unintentional line breaks in addresses going forward.

BTW, it's still straightforward to introduce additional line breaks
deliberately.