### PR TITLE
Restore behaviour of headings being able to be rendered inside example boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.8.2
+
+* Fix a bug where headings were no longer rendering inside example boxes ([#374](https://github.com/alphagov/govspeak/pull/374))
+
 ## 8.8.1
 
 * Update dependencies

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -296,7 +296,7 @@ module Govspeak
     extension("example", surrounded_by("$E")) do |body|
       <<~BODY
         <div class="example" markdown="1">
-          #{body.strip.gsub(/\A^\|/, "\n|").gsub(/\|$\Z/, "|\n")}
+        #{body.strip.gsub(/\A^\|/, "\n|").gsub(/\|$\Z/, "|\n")}
         </div>
       BODY
     end

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "8.8.1".freeze
+  VERSION = "8.8.2".freeze
 end

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -1335,6 +1335,22 @@ Teston
   end
 
   test_given_govspeak "
+    $E
+
+    ### A heading within an example
+
+    Some example content
+
+    $E" do
+    assert_html_output %(
+    <div class="example">
+    <h3 id="a-heading-within-an-example">A heading within an example</h3>
+
+    <p>Some example content</p>
+  </div>)
+  end
+
+  test_given_govspeak "
     $LegislativeList
     * 1. Item 1[^1] with an ACRONYM
     * 2. Item 2[^2]


### PR DESCRIPTION
This is technically against govspeak usage guidance, but was behaviour that worked before, and the changing of implementation for example blocks in https://github.com/alphagov/govspeak/pull/350 broke it. 

Changing back to previous behaviour for now until more work is done on govspeak components and their interactions.

The strange behaviour with spacing appears to be related to this issue, credit to @brucebolt  https://github.com/gettalong/kramdown/issues/213 

Trello: https://trello.com/c/UVePLiKZ/1481-re-enable-headings-inside-example-boxes-in-govspeak

 ⚠️ This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs. ⚠️ 


