### PR TITLE
Release version 9.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 9.0.0
 
 * Remove Advisory component ([#357](https://github.com/alphagov/govspeak/pull/357))
 

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "8.8.3".freeze
+  VERSION = "9.0.0".freeze
 end


### PR DESCRIPTION
Bump the version to 8.9.0
Changes included:
* Remove Advisory component ([#357](https://github.com/alphagov/govspeak/pull/357))


