### PR TITLE
Add GA4 indexes to attachments that render a details component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Add GA4 indexes to attachments that render a details component ([#385](https://github.com/alphagov/govspeak/pull/385))
+
 ## 10.0.1
 
 * Update dependencies

--- a/lib/govspeak/post_processor.rb
+++ b/lib/govspeak/post_processor.rb
@@ -57,6 +57,11 @@ module Govspeak
     end
 
     extension("embed attachment HTML") do |document|
+      # Attachments with details components need indexes set for GA4 tracking purposes
+      details_attachments = govspeak_document.attachments.select { |attachment| attachment[:alternative_format_contact_email] }
+      details_attachments_size = details_attachments.size
+      details_attachment_index = 0
+
       document.css("govspeak-embed-attachment").map do |el|
         attachment = govspeak_document.attachments.detect { |a| a[:id] == el["id"] }
 
@@ -65,11 +70,17 @@ module Govspeak
           next
         end
 
+        if attachment[:alternative_format_contact_email]
+          details_attachment_index += 1
+          details_ga4_attributes = { index_section: details_attachment_index, index_section_count: details_attachments_size }
+        end
+
         attachment_html = GovukPublishingComponents.render(
           "govuk_publishing_components/components/attachment",
           attachment:,
           margin_bottom: 6,
           locale: govspeak_document.locale,
+          details_ga4_attributes:,
         )
         el.swap(attachment_html)
       end


### PR DESCRIPTION
## What / Why
- Attachments that have an `alternative_format_contact_email` render a `details` component on them: https://components.publishing.service.gov.uk/component-guide/attachment/with_contact_email
- The performance analysts would like to be able to track which number each details element is on the page
- Therefore we need to set `index_section` (the index of the details component) and `index_section_count` (the total number of these attachments on the page)
- Therefore, I've written some code to achieve this

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.


