### PR TITLE
Release version 10.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 10.1.0
 
 * Allow acronyms/abbreviations in steps ([#387](https://github.com/alphagov/govspeak/pull/387)).
 * Add GA4 indexes to attachments that render a details component ([#385](https://github.com/alphagov/govspeak/pull/385))

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "10.0.1".freeze
+  VERSION = "10.1.0".freeze
 end


### PR DESCRIPTION
## 10.1.0

* Allow acronyms/abbreviations in steps ([#387](https://github.com/alphagov/govspeak/pull/387)).
* Add GA4 indexes to attachments that render a details component ([#385](https://github.com/alphagov/govspeak/pull/385))