### PR TITLE
Allow acronyms/abbreviations in steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Allow acronyms/abbreviations in steps ([#387](https://github.com/alphagov/govspeak/pull/387)).
 * Add GA4 indexes to attachments that render a details component ([#385](https://github.com/alphagov/govspeak/pull/385))
 
 ## 10.0.1

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -317,10 +317,19 @@ module Govspeak
     end
 
     extension("numbered list", /^[ \t]*((s\d+\.\s.*(?:\n|$))+)/) do |body|
-      body.gsub!(/s(\d+)\.\s(.*)(?:\n|$)/) do
-        "<li>#{Govspeak::Document.new(Regexp.last_match(2).strip, attachments:).to_html}</li>\n"
+      li_elements = body.gsub!(/s(\d+)\.\s(.*)(?:\n|$)/).map do
+        element = <<~BODY
+          <li markdown="1">
+            #{Regexp.last_match(2).strip}
+          </li>
+        BODY
+        element.strip
       end
-      %(<ol class="steps">\n#{body}</ol>)
+      <<~BODY
+        <ol class="steps">
+          #{li_elements.join("\n  ")}
+        </ol>
+      BODY
     end
 
     def self.devolved_options

--- a/test/govspeak_attachment_link_test.rb
+++ b/test/govspeak_attachment_link_test.rb
@@ -58,13 +58,13 @@ class GovspeakAttachmentLinkTest < Minitest::Test
 
     expected_output = <<~TEXT
       <ol class="steps">
-      <li>
-      <p>First item with <span class="gem-c-attachment-link">
+        <li>
+          <p>First item with <span class="gem-c-attachment-link">
         <a class="govuk-link" href="http://example.com/attachment.pdf">Attachment Title</a>  </span></p>
-      </li>
-      <li>
-      <p>Second item without attachment</p>
-      </li>
+        </li>
+        <li>
+          <p>Second item without attachment</p>
+        </li>
       </ol>
     TEXT
 

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -600,6 +600,23 @@ Teston
   end
 
   test_given_govspeak "
+    s1. This is number 1.
+    s2. This is number 2 with an ACRONYM.
+
+    *[ACRONYM]: This is the acronym explanation" do
+    assert_html_output <<~HTML
+      <ol class="steps">
+        <li>
+          <p>This is number 1.</p>
+        </li>
+        <li>
+          <p>This is number 2 with an <abbr title="This is the acronym explanation">ACRONYM</abbr>.</p>
+        </li>
+      </ol>
+    HTML
+  end
+
+  test_given_govspeak "
     $CTA
     [external link](http://www.external.com) some text
     $CTA

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -582,18 +582,18 @@ Teston
           <p>This is a test:</p>
 
           <ol class="steps">
-        <li>
-        <p>This is number 1.</p>
-        </li>
-        <li>
-        <p>This is number 2.</p>
-        </li>
-        <li>
-        <p>This is number 3.</p>
-        </li>
-        <li>
-        <p>This is number 4.</p>
-        </li>
+          <li>
+              <p>This is number 1.</p>
+            </li>
+          <li>
+              <p>This is number 2.</p>
+            </li>
+          <li>
+              <p>This is number 3.</p>
+            </li>
+          <li>
+              <p>This is number 4.</p>
+            </li>
         </ol>
         </div>
         )
@@ -858,15 +858,15 @@ Teston
     " do
     assert_html_output %(
       <ol class="steps">
-      <li>
-      <p>zippy</p>
-      </li>
-      <li>
-      <p>bungle</p>
-      </li>
-      <li>
-      <p>george</p>
-      </li>
+        <li>
+          <p>zippy</p>
+        </li>
+        <li>
+          <p>bungle</p>
+        </li>
+        <li>
+          <p>george</p>
+        </li>
       </ol>)
     assert_text_output "zippy bungle george"
   end
@@ -885,12 +885,12 @@ Teston
       </ul>
 
       <ol class="steps">
-      <li>
-      <p>step</p>
-      </li>
-      <li>
-      <p>list</p>
-      </li>
+        <li>
+          <p>step</p>
+        </li>
+        <li>
+          <p>list</p>
+        </li>
       </ol>)
     assert_text_output "unordered list step list"
   end


### PR DESCRIPTION
Abbreviations were not working when embedded in a step.

Fixing this in the same way as abbreviations in legislative lists: wrapping the list item in an element that has a `markdown="1"` value defined, then indenting the contents correctly so that the markdown is parsed again during the second round of processing.

Note: this affects the indentation, so the existing tests are being updated to reflect that.

[Trello card](https://trello.com/c/Pou7iXR4)


