### PR TITLE
Remove trailing space from CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ## 8.8.3
 
-* Update dependencies (actionview < 8.0.2, sanitize < 8, rubocop-govuk = 5.0.7) 
+* Update dependencies (actionview < 8.0.2, sanitize < 8, rubocop-govuk = 5.0.7)
 
 ## 8.8.2
 


### PR DESCRIPTION
My IDE was removing this each space each time I saved the file, affecting my diff.

Removing it in a separate commit.