### PR TITLE
Revert "Add GA4 indexes to attachments that render a details component"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 10.2.0
+
+* Revert 'Add GA4 indexes to attachments that render a details component' ([#389](https://github.com/alphagov/govspeak/pull/389))
+
 ## 10.1.0
 
 * Allow acronyms/abbreviations in steps ([#387](https://github.com/alphagov/govspeak/pull/387)).

--- a/lib/govspeak/post_processor.rb
+++ b/lib/govspeak/post_processor.rb
@@ -57,11 +57,6 @@ module Govspeak
     end
 
     extension("embed attachment HTML") do |document|
-      # Attachments with details components need indexes set for GA4 tracking purposes
-      details_attachments = govspeak_document.attachments.select { |attachment| attachment[:alternative_format_contact_email] }
-      details_attachments_size = details_attachments.size
-      details_attachment_index = 0
-
       document.css("govspeak-embed-attachment").map do |el|
         attachment = govspeak_document.attachments.detect { |a| a[:id] == el["id"] }
 
@@ -70,17 +65,11 @@ module Govspeak
           next
         end
 
-        if attachment[:alternative_format_contact_email]
-          details_attachment_index += 1
-          details_ga4_attributes = { index_section: details_attachment_index, index_section_count: details_attachments_size }
-        end
-
         attachment_html = GovukPublishingComponents.render(
           "govuk_publishing_components/components/attachment",
           attachment:,
           margin_bottom: 6,
           locale: govspeak_document.locale,
-          details_ga4_attributes:,
         )
         el.swap(attachment_html)
       end

--- a/test/govspeak_attachment_test.rb
+++ b/test/govspeak_attachment_test.rb
@@ -52,32 +52,4 @@ class GovspeakAttachmentTest < Minitest::Test
     assert html_has_selector?(rendered, "section.gem-c-attachment")
     assert_match(/<p>some more text<\/p>/, rendered)
   end
-
-  test "renders attachments with details elements with the correct GA4 index" do
-    attachments = []
-
-    (1..3).each do |index|
-      attachments << {
-        id: "attachment#{index}.ods",
-        url: "http://example.com/attachment#{index}",
-        title: "Attachment Title #{index}",
-        alternative_format_contact_email: "example@gov.uk",
-      }
-    end
-
-    # Insert an attachment without a details element, to ensure our code to increment the index ignores these
-    attachments.insert(1, {
-      id: "attachment.pdf",
-      url: "http://example.com/attachment.pdf",
-      title: "Attachment Title",
-    })
-
-    rendered = render_govspeak("[Attachment:attachment1.ods]\n[Attachment:attachment.pdf]\n[Attachment:attachment2.ods]\n[Attachment:attachment3.ods]", attachments)
-    node = Nokogiri::HTML(rendered)
-    node.css(".gem-c-details").each_with_index.map do |details, index|
-      ga4_event = JSON.parse(details.attribute("data-ga4-event"))
-      assert_equal ga4_event["index_section"], index + 1
-      assert_equal ga4_event["index_section_count"], 3
-    end
-  end
 end


### PR DESCRIPTION
This reverts commit ecdda77d0f39e115ae3b4d2a73f6fd0fd94e915f.

The code was working, but it isn't giving us exactly what we want - it was returning the count of all attachments for a given document, but we weren't aware that attachments can be added to a document but not rendered, or they can be rendered as an attachment link instead. We only want a count of attachments that are actually being rendered on the page, and are rendering as an `attachment` component. Therefore we'll explore using JS to handle this as I assume it'll be computationally expensive to try and get a total count of documents that are actually rendered as `attachment` components through `govspeak`, when we may be able to write some JS on the rendered page to group `attachment` components within the content and get the total count that way.

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.


