### PR TITLE
Update version.rb to 10.2.0

### DIFF
--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "10.1.0".freeze
+  VERSION = "10.2.0".freeze
 end


### PR DESCRIPTION
I updated the changelog in https://github.com/alphagov/govspeak/pull/389, but I didn't update `version.rb` so a release wasn't created.

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.


