### PR TITLE
Release 10.3.0 Welsh translation improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 10.3.0
+
+* Add Welsh translations for various components: devolved content headings, footnote labels, and image credit labels ([#417](https://github.com/alphagov/govspeak/pull/417))
+
 ## 10.2.5
 
 * Update dependencies

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "10.2.5".freeze
+  VERSION = "10.3.0".freeze
 end


### PR DESCRIPTION
Missed in #417

Not sure if this counts as a breaking/major change 🤔

[Trello](https://trello.com/c/MGfVI5Dq/1714-investigate-a-support-ticket-the-word-footnote-on-a-footnote-isnt-translated-into-welsh)
