### PR TITLE
Support abbreviations in informational

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 10.4.0
 
 * Support abbreviations in informationals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Support abbreviations in informationals
+
 ## 10.3.0
 
 * Add Welsh translations for various components: devolved content headings, footnote labels, and image credit labels ([#417](https://github.com/alphagov/govspeak/pull/417))

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -206,8 +206,11 @@ module Govspeak
     end
 
     extension("informational", surrounded_by("^")) do |body|
-      %(\n\n<div role="note" aria-label="Information" class="application-notice info-notice">
-#{Govspeak::Document.new(body.strip).to_html}</div>\n)
+      <<~BODY
+        \n\n<div role="note" aria-label="Information" class="application-notice info-notice" markdown="1">
+        #{body.strip}
+        </div>
+      BODY
     end
 
     extension("helpful", surrounded_by("%")) do |body|

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "10.3.0".freeze
+  VERSION = "10.4.0".freeze
 end

--- a/test/govspeak_informational_test.rb
+++ b/test/govspeak_informational_test.rb
@@ -4,29 +4,35 @@ require "govspeak_test_helper"
 class GovspeakImagesTest < Minitest::Test
   include GovspeakTestHelper
 
-  test_given_govspeak("^ I am very informational ^") do
-    assert_html_output %(
-      <div role="note" aria-label="Information" class="application-notice info-notice">
-      <p>I am very informational</p>
-      </div>)
-    assert_text_output "I am very informational"
+  test "renders okay with just an opening tag" do
+    given_govspeak "^ I am very informational" do
+      assert_html_output %(
+        <div role="note" aria-label="Information" class="application-notice info-notice">
+        <p>I am very informational</p>
+        </div>)
+      assert_text_output "I am very informational"
+    end
   end
 
-  test_given_govspeak "The following is very informational\n^ I am very informational ^" do
-    assert_html_output %(
-      <p>The following is very informational</p>
-
-      <div role="note" aria-label="Information" class="application-notice info-notice">
-      <p>I am very informational</p>
-      </div>)
-    assert_text_output "The following is very informational I am very informational"
+  test "renders okay with opening and closing tags" do
+    given_govspeak("^ I am very informational ^") do
+      assert_html_output %(
+        <div role="note" aria-label="Information" class="application-notice info-notice">
+        <p>I am very informational</p>
+        </div>)
+      assert_text_output "I am very informational"
+    end
   end
 
-  test_given_govspeak "^ I am very informational" do
-    assert_html_output %(
-      <div role="note" aria-label="Information" class="application-notice info-notice">
-      <p>I am very informational</p>
-      </div>)
-    assert_text_output "I am very informational"
+  test "avoids combining into a single block with an immediately-preceding line" do
+    given_govspeak "The following is very informational\n^ I am very informational ^" do
+      assert_html_output %(
+        <p>The following is very informational</p>
+
+        <div role="note" aria-label="Information" class="application-notice info-notice">
+        <p>I am very informational</p>
+        </div>)
+      assert_text_output "The following is very informational I am very informational"
+    end
   end
 end

--- a/test/govspeak_informational_test.rb
+++ b/test/govspeak_informational_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+require "govspeak_test_helper"
+
+class GovspeakImagesTest < Minitest::Test
+  include GovspeakTestHelper
+
+  test_given_govspeak("^ I am very informational ^") do
+    assert_html_output %(
+      <div role="note" aria-label="Information" class="application-notice info-notice">
+      <p>I am very informational</p>
+      </div>)
+    assert_text_output "I am very informational"
+  end
+
+  test_given_govspeak "The following is very informational\n^ I am very informational ^" do
+    assert_html_output %(
+      <p>The following is very informational</p>
+
+      <div role="note" aria-label="Information" class="application-notice info-notice">
+      <p>I am very informational</p>
+      </div>)
+    assert_text_output "The following is very informational I am very informational"
+  end
+
+  test_given_govspeak "^ I am very informational" do
+    assert_html_output %(
+      <div role="note" aria-label="Information" class="application-notice info-notice">
+      <p>I am very informational</p>
+      </div>)
+    assert_text_output "I am very informational"
+  end
+end

--- a/test/govspeak_informational_test.rb
+++ b/test/govspeak_informational_test.rb
@@ -3,6 +3,7 @@ require "govspeak_test_helper"
 
 class GovspeakImagesTest < Minitest::Test
   include GovspeakTestHelper
+  extend Minitest::Spec::DSL
 
   test "renders okay with just an opening tag" do
     given_govspeak "^ I am very informational" do
@@ -24,6 +25,16 @@ class GovspeakImagesTest < Minitest::Test
     end
   end
 
+  test "renders okay with no space after the opening tag" do
+    given_govspeak("^I am very informational") do
+      assert_html_output %(
+        <div role="note" aria-label="Information" class="application-notice info-notice">
+        <p>I am very informational</p>
+        </div>)
+      assert_text_output "I am very informational"
+    end
+  end
+
   test "avoids combining into a single block with an immediately-preceding line" do
     given_govspeak "The following is very informational\n^ I am very informational ^" do
       assert_html_output %(
@@ -33,6 +44,38 @@ class GovspeakImagesTest < Minitest::Test
         <p>I am very informational</p>
         </div>)
       assert_text_output "The following is very informational I am very informational"
+    end
+  end
+
+  describe "support for nested Kramdown" do
+    test "supports headings" do
+      given_govspeak "^ ## I am an informational heading" do
+        assert_html_output %(
+        <div role="note" aria-label="Information" class="application-notice info-notice">
+        <h2 id="i-am-an-informational-heading">I am an informational heading</h2>
+        </div>)
+        assert_text_output "I am an informational heading"
+      end
+    end
+
+    test "supports links" do
+      given_govspeak "^ [My informational link](https://www.gov.uk)" do
+        assert_html_output %(
+          <div role="note" aria-label="Information" class="application-notice info-notice">
+          <p><a href="https://www.gov.uk">My informational link</a></p>
+          </div>)
+        assert_text_output "My informational link"
+      end
+    end
+
+    test "supports bold emphasis" do
+      given_govspeak "^ I am **very** informational" do
+        assert_html_output %(
+          <div role="note" aria-label="Information" class="application-notice info-notice">
+          <p>I am <strong>very</strong> informational</p>
+          </div>)
+        assert_text_output "I am very informational"
+      end
     end
   end
 end

--- a/test/govspeak_informational_test.rb
+++ b/test/govspeak_informational_test.rb
@@ -8,9 +8,9 @@ class GovspeakImagesTest < Minitest::Test
   test "renders okay with just an opening tag" do
     given_govspeak "^ I am very informational" do
       assert_html_output %(
-        <div role="note" aria-label="Information" class="application-notice info-notice">
+      <div role="note" aria-label="Information" class="application-notice info-notice">
         <p>I am very informational</p>
-        </div>)
+      </div>)
       assert_text_output "I am very informational"
     end
   end
@@ -18,9 +18,9 @@ class GovspeakImagesTest < Minitest::Test
   test "renders okay with opening and closing tags" do
     given_govspeak("^ I am very informational ^") do
       assert_html_output %(
-        <div role="note" aria-label="Information" class="application-notice info-notice">
+      <div role="note" aria-label="Information" class="application-notice info-notice">
         <p>I am very informational</p>
-        </div>)
+      </div>)
       assert_text_output "I am very informational"
     end
   end
@@ -28,9 +28,9 @@ class GovspeakImagesTest < Minitest::Test
   test "renders okay with no space after the opening tag" do
     given_govspeak("^I am very informational") do
       assert_html_output %(
-        <div role="note" aria-label="Information" class="application-notice info-notice">
+      <div role="note" aria-label="Information" class="application-notice info-notice">
         <p>I am very informational</p>
-        </div>)
+      </div>)
       assert_text_output "I am very informational"
     end
   end
@@ -41,7 +41,7 @@ class GovspeakImagesTest < Minitest::Test
         <p>The following is very informational</p>
 
         <div role="note" aria-label="Information" class="application-notice info-notice">
-        <p>I am very informational</p>
+          <p>I am very informational</p>
         </div>)
       assert_text_output "The following is very informational I am very informational"
     end
@@ -52,9 +52,26 @@ class GovspeakImagesTest < Minitest::Test
       given_govspeak "^ ## I am an informational heading" do
         assert_html_output %(
         <div role="note" aria-label="Information" class="application-notice info-notice">
-        <h2 id="i-am-an-informational-heading">I am an informational heading</h2>
+          <h2 id="i-am-an-informational-heading">I am an informational heading</h2>
         </div>)
         assert_text_output "I am an informational heading"
+      end
+    end
+
+    test "supports abbreviations" do
+      given_govspeak "^ I am very informational
+
+  Live, love, informational
+
+  *[informational]: do with it what you will
+      " do
+        assert_html_output %(
+          <div role="note" aria-label="Information" class="application-notice info-notice">
+            <p>I am very <abbr title="do with it what you will">informational</abbr></p>
+          </div>
+
+          <p>Live, love, <abbr title="do with it what you will">informational</abbr></p>)
+        assert_text_output "I am very informational Live, love, informational"
       end
     end
 
@@ -62,8 +79,9 @@ class GovspeakImagesTest < Minitest::Test
       given_govspeak "^ [My informational link](https://www.gov.uk)" do
         assert_html_output %(
           <div role="note" aria-label="Information" class="application-notice info-notice">
-          <p><a href="https://www.gov.uk">My informational link</a></p>
-          </div>)
+            <p><a href="https://www.gov.uk">My informational link</a></p>
+          </div>
+        )
         assert_text_output "My informational link"
       end
     end
@@ -72,8 +90,9 @@ class GovspeakImagesTest < Minitest::Test
       given_govspeak "^ I am **very** informational" do
         assert_html_output %(
           <div role="note" aria-label="Information" class="application-notice info-notice">
-          <p>I am <strong>very</strong> informational</p>
-          </div>)
+            <p>I am <strong>very</strong> informational</p>
+          </div>
+        )
         assert_text_output "I am very informational"
       end
     end

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -177,36 +177,10 @@ Teston
     assert_equal %(<p>Paragraph1</p>\n\n<div class="address"><div class="adr org fn"><p>\n123 Test Street<br>Testcase Cliffs<br>Teston<br>0123 456 7890\n</p></div></div>\n), doc.to_html
   end
 
-  test_given_govspeak("^ I am very informational ^") do
-    assert_html_output %(
-      <div role="note" aria-label="Information" class="application-notice info-notice">
-      <p>I am very informational</p>
-      </div>)
-    assert_text_output "I am very informational"
-  end
-
   test "processing an extension does not modify the provided input" do
     input = "^ I am very informational"
     Govspeak::Document.new(input).to_html
     assert_equal "^ I am very informational", input
-  end
-
-  test_given_govspeak "The following is very informational\n^ I am very informational ^" do
-    assert_html_output %(
-      <p>The following is very informational</p>
-
-      <div role="note" aria-label="Information" class="application-notice info-notice">
-      <p>I am very informational</p>
-      </div>)
-    assert_text_output "The following is very informational I am very informational"
-  end
-
-  test_given_govspeak "^ I am very informational" do
-    assert_html_output %(
-      <div role="note" aria-label="Information" class="application-notice info-notice">
-      <p>I am very informational</p>
-      </div>)
-    assert_text_output "I am very informational"
   end
 
   test_given_govspeak "% I am very helpful %" do


### PR DESCRIPTION
[Trello](https://trello.com/c/RFo81qsP/1731-hover-markdown-not-appearing-in-callout-box)

Take a look at this

<img width="283" alt="image" src="https://github.com/user-attachments/assets/48aaa053-e5c1-4cea-8bae-7bded7b3f27e" />
