### PR TITLE
[PP-7224] Pass locale to nested calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Pass locale to child instances of `Govspeak::Document` (where one instance instantiates another) and to `HtmlValidator`
+
 ## 10.4.1
 
 * Update dependencies

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -94,7 +94,10 @@ module Govspeak
     end
 
     def valid?(validation_options = {})
-      Govspeak::HtmlValidator.new(@source, validation_options).valid?
+      Govspeak::HtmlValidator.new(
+        @source,
+        validation_options.merge({ locale: @locale }),
+      ).valid?
     end
 
     def headers

--- a/lib/govspeak/html_validator.rb
+++ b/lib/govspeak/html_validator.rb
@@ -4,6 +4,7 @@ class Govspeak::HtmlValidator
   def initialize(govspeak_string, options = {})
     @govspeak_string = govspeak_string.dup.force_encoding(Encoding::UTF_8)
     @allowed_image_hosts = options[:allowed_image_hosts]
+    @locale = options[:locale]
   end
 
   def invalid?
@@ -28,6 +29,7 @@ private
       govspeak_string,
       sanitize:,
       allowed_image_hosts: @allowed_image_hosts,
+      locale: @locale,
     ).to_html
   end
 end


### PR DESCRIPTION
- Pass in a `Govspeak::Document`'s locale to any `Govspeak::Document`s it instantiates
- Use locale in `HtmlValidator` (essentially a nested call)