### PR TITLE
Remove legacy comments

### DIFF
--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -200,7 +200,6 @@ module Govspeak
 #{Govspeak::Document.new(body.strip).to_html}</div>\n)
     end
 
-    # FIXME: these surrounded_by arguments look dodgy
     extension("external", surrounded_by("x[", ")x")) do |body|
       Kramdown::Document.new("[#{body.strip}){:rel='external'}").to_html
     end

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -341,8 +341,6 @@ Teston
 
   # Regression test - the surrounded_by helper doesn't require the closing x
   # so 'xaa' was getting picked up by the external link helper above
-  # TODO: review whether we should require closing symbols for these extensions
-  #       need to check all existing content.
   test_given_govspeak "xaa" do
     assert_html_output "<p>xaa</p>"
     assert_text_output "xaa"


### PR DESCRIPTION
These `FIXME` and `TODO` comments have been present for 13 years without any action being taken.

There appears to be no action for us to take, nor any need for that to have been taken in those years, so removing them.