### PR TITLE
[PP-7224] Fall back to English on invalid locale or missing translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Pass locale to child instances of `Govspeak::Document` (where one instance instantiates another) and to `HtmlValidator`
+* Fall back to English when provided with on invalid locale or a translation is not available for the given locale
 
 ## 10.4.1
 

--- a/govspeak.gemspec
+++ b/govspeak.gemspec
@@ -40,6 +40,7 @@ library for use in the UK Government Single Domain project'
   s.add_dependency "sanitize", ">= 6", "< 8"
 
   s.add_development_dependency "minitest", "~> 5.14"
+  s.add_development_dependency "mocha"
   s.add_development_dependency "pry-byebug"
   s.add_development_dependency "rake"
   s.add_development_dependency "rubocop-govuk", "5.1.17"

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -17,6 +17,7 @@ require "govspeak/blockquote_extra_quote_remover"
 require "govspeak/post_processor"
 require "govspeak/link_extractor"
 require "govspeak/template_renderer"
+require "govspeak/translation_helper"
 require "govspeak/presenters/attachment_presenter"
 require "govspeak/presenters/contact_presenter"
 require "govspeak/presenters/h_card_presenter"
@@ -363,7 +364,10 @@ module Govspeak
         "devolved-#{devolved_option}",
         /:#{devolved_option}:(.*?):#{devolved_option}:/m,
       ) do |body|
-        header_content = I18n.t("govspeak.devolved.#{devolved_option}", locale:)
+        header_content = Govspeak::TranslationHelper.t_with_fallback(
+          "govspeak.devolved.#{devolved_option}",
+          locale:,
+        )
         body_content = Govspeak::Document
           .new(body.strip, locale: @locale)
           .to_html
@@ -437,3 +441,5 @@ end
 I18n.load_path.unshift(
   *Dir.glob(File.expand_path("locales/*.yml", Govspeak.root)),
 )
+
+I18n.default_locale = :en

--- a/lib/govspeak/post_processor.rb
+++ b/lib/govspeak/post_processor.rb
@@ -150,12 +150,12 @@ module Govspeak
     extension("use custom footnotes") do |document|
       document.css("a.footnote").map do |el|
         footnote_number = el[:href].gsub(/\D/, "")
-        label = I18n.t("govspeak.footnote.label", locale: govspeak_document.locale)
+        label = Govspeak::TranslationHelper.t_with_fallback("govspeak.footnote.label", locale: govspeak_document.locale)
         el.inner_html = "[#{label} #{footnote_number}]"
       end
       document.css("[role='doc-backlink']").map do |el|
         backlink_number = " #{el.css('sup')[0].content}" if el.css("sup")[0].present?
-        aria_label = I18n.t("govspeak.footnote.backlink_aria_label", locale: govspeak_document.locale)
+        aria_label = Govspeak::TranslationHelper.t_with_fallback("govspeak.footnote.backlink_aria_label", locale: govspeak_document.locale)
         el["aria-label"] = "#{aria_label}#{backlink_number}"
       end
     end

--- a/lib/govspeak/presenters/image_presenter.rb
+++ b/lib/govspeak/presenters/image_presenter.rb
@@ -35,7 +35,7 @@ module Govspeak
       lines = []
       lines << "<figcaption>"
       lines << %(<p>#{caption}</p>) if caption.present?
-      lines << %(<p>#{I18n.t('govspeak.image.figure.credit', credit:, locale:)}</p>) if credit.present?
+      lines << %(<p>#{Govspeak::TranslationHelper.t_with_fallback('govspeak.image.figure.credit', credit:, locale:)}</p>) if credit.present?
       lines << "</figcaption>"
       lines.join
     end

--- a/lib/govspeak/template_renderer.rb
+++ b/lib/govspeak/template_renderer.rb
@@ -14,10 +14,8 @@ module Govspeak
       erb.result(template_binding)
     end
 
-    def t(*args)
-      options = args.last.is_a?(Hash) ? args.last.dup : {}
-      key = args.shift
-      I18n.t!(key, **options.merge(locale:))
+    def t(key, **options)
+      Govspeak::TranslationHelper.t_with_fallback(key, **options.merge(locale:))
     end
 
     def format_with_html_line_breaks(string)

--- a/lib/govspeak/translation_helper.rb
+++ b/lib/govspeak/translation_helper.rb
@@ -1,7 +1,9 @@
 module Govspeak
   module TranslationHelper
     def self.t_with_fallback(key, **options)
-      options[:locale] ||= I18n.default_locale
+      if I18n.available_locales.none?(options[:locale]&.to_sym)
+        options[:locale] = I18n.default_locale
+      end
 
       if options[:locale] != I18n.default_locale
         options[:default] = I18n.t(

--- a/lib/govspeak/translation_helper.rb
+++ b/lib/govspeak/translation_helper.rb
@@ -1,0 +1,16 @@
+module Govspeak
+  module TranslationHelper
+    def self.t_with_fallback(key, **options)
+      options[:locale] ||= I18n.default_locale
+
+      if options[:locale] != I18n.default_locale
+        options[:default] = I18n.t(
+          key,
+          **options.merge(locale: I18n.default_locale),
+        )
+      end
+
+      I18n.t(key, **options)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,7 @@ require "bundler"
 Bundler.setup :default, :development, :test
 
 require "minitest/autorun"
+require "mocha/minitest"
 
 require "support/html_helpers"
 

--- a/test/translation_helper_test.rb
+++ b/test/translation_helper_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class TranslationHelperTest < Minitest::Test
+  extend Minitest::Spec::DSL
+
+  describe ".t_with_fallback" do
+    before do
+      I18n.expects(:available_locales).returns(%i[en cy])
+      I18n
+        .expects(:default_locale)
+        .at_least_once
+        .at_most(2)
+        .returns(:en)
+    end
+
+    it "passes the provided key and options with a locale to I18n.t" do
+      I18n.expects(:t).with(
+        "whatever",
+        a_translation_variable: "my favourite value",
+        locale: instance_of(Symbol),
+      )
+
+      Govspeak::TranslationHelper.t_with_fallback(
+        "whatever",
+        a_translation_variable: "my favourite value",
+      )
+    end
+
+    it "passes the default locale to I18n.t when matching the provided locale" do
+      I18n.expects(:t).with("whatever", locale: :en)
+      Govspeak::TranslationHelper.t_with_fallback("whatever", locale: :en)
+    end
+
+    it "passes a fallback translation using the default locale to I18n.t when the provided locale is supported but non-default" do
+      I18n.expects(:t).with("whatever", locale: :en).returns("WHATEVER!")
+      I18n.expects(:t).with("whatever", locale: :cy, default: "WHATEVER!")
+
+      Govspeak::TranslationHelper.t_with_fallback("whatever", locale: :cy)
+    end
+
+    it "passes the default locale to I18n.t when a locale is not provided" do
+      I18n.expects(:t).with("whatever", locale: :en)
+      Govspeak::TranslationHelper.t_with_fallback("whatever")
+    end
+  end
+end

--- a/test/translation_helper_test.rb
+++ b/test/translation_helper_test.rb
@@ -38,6 +38,11 @@ class TranslationHelperTest < Minitest::Test
       Govspeak::TranslationHelper.t_with_fallback("whatever", locale: :cy)
     end
 
+    it "passes the default locale to I18n.t when the provided locale is unsupported" do
+      I18n.expects(:t).with("whatever", locale: :en)
+      Govspeak::TranslationHelper.t_with_fallback("whatever", locale: :yo)
+    end
+
     it "passes the default locale to I18n.t when a locale is not provided" do
       I18n.expects(:t).with("whatever", locale: :en)
       Govspeak::TranslationHelper.t_with_fallback("whatever")


### PR DESCRIPTION
We currently return an error string when provided with an invalid locale or a locale which doesn't have a required translation. Our support for locales has been expanded recently, so this might not be affecting any content (not much time for uptake), but we should address this so that it doesn't become an issue further down the line