### PR TITLE
[PP-7224] Fix Chinese locale names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Fix English and native names of Chinese locales
+
 ## 10.6.0
 
 * Expose supported locales with their codes, English names, and native names:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 10.6.1
 
 * Fix English and native names of Chinese locales
 

--- a/lib/govspeak/version.rb
+++ b/lib/govspeak/version.rb
@@ -1,3 +1,3 @@
 module Govspeak
-  VERSION = "10.6.0".freeze
+  VERSION = "10.6.1".freeze
 end

--- a/locales/zh-hk.yml
+++ b/locales/zh-hk.yml
@@ -1,7 +1,7 @@
 ---
 zh-hk:
-  english_name: Cantonese
-  native_name: 粵語
+  english_name: Traditional Chinese (Hong Kong)
+  native_name: 繁體中文（香港）
   govspeak:
     contact:
       contact_form: "聯絡資料表"

--- a/locales/zh-tw.yml
+++ b/locales/zh-tw.yml
@@ -1,7 +1,7 @@
 ---
 zh-tw:
-  english_name: Traditional Chinese
-  native_name: 繁體中文
+  english_name: Traditional Chinese (Taiwan)
+  native_name: 繁體中文（臺灣）
   govspeak:
     contact:
       contact_form: "聯絡資料表"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -1,7 +1,7 @@
 ---
 zh:
-  english_name: Chinese
-  native_name: 中文
+  english_name: Simplified Chinese
+  native_name: 简体中文
   govspeak:
     contact:
       contact_form: "联系表格"

--- a/test/translation_helper_test.rb
+++ b/test/translation_helper_test.rb
@@ -97,13 +97,21 @@ class TranslationHelperTest < Minitest::Test
         { code: :ur, english_name: "Urdu", native_name: "اردو" },
         { code: :uz, english_name: "Uzbek", native_name: "Oʻzbek" },
         { code: :vi, english_name: "Vietnamese", native_name: "Tiếng Việt" },
-        { code: :"zh-hk", english_name: "Cantonese", native_name: "粵語" },
+        {
+          code: :"zh-hk",
+          english_name: "Traditional Chinese (Hong Kong)",
+          native_name: "繁體中文（香港）",
+        },
         {
           code: :"zh-tw",
-          english_name: "Traditional Chinese",
-          native_name: "繁體中文",
+          english_name: "Traditional Chinese (Taiwan)",
+          native_name: "繁體中文（臺灣）",
         },
-        { code: :zh, english_name: "Chinese", native_name: "中文" },
+        {
+          code: :zh,
+          english_name: "Simplified Chinese",
+          native_name: "简体中文",
+        },
       ]
     end
   end


### PR DESCRIPTION
Per recent changes in Frontend, Government Frontend, and Whitehall, this updates the English and native names for Chinese locales to be more precise/accurate