### PR TITLE
fix: When finding/returning headers, filter links from header titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# Unreleased
+
+* fix: When finding/returning headers, filter links from header titles [PR #439](https://github.com/alphagov/govspeak/pull/439)
+
 ## 10.6.5
 
 * Update dependencies

--- a/lib/govspeak/header_extractor.rb
+++ b/lib/govspeak/header_extractor.rb
@@ -20,11 +20,15 @@ module Govspeak
   private
 
     def id(element)
-      element.attr.fetch("id", generate_id(element.options[:raw_text]))
+      element.attr.fetch("id", generate_id(text_with_links(element)))
     end
 
     def build_header(element)
-      Header.new(element.options[:raw_text], element.options[:level], id(element))
+      Header.new(text_with_links(element), element.options[:level], id(element))
+    end
+
+    def text_with_links(element)
+      element.options[:raw_text].gsub(/\[(.+)\]\((.*)\)/, '\1')
     end
 
     def find_headers(parent)

--- a/test/govspeak_structured_headers_test.rb
+++ b/test/govspeak_structured_headers_test.rb
@@ -29,6 +29,8 @@ class GovspeakStructuredHeadersTest < Minitest::Test
 
 ## Heading 5
 
+### [Heading 5.1](https://www.example.com)
+
     )
   end
 
@@ -65,6 +67,11 @@ class GovspeakStructuredHeadersTest < Minitest::Test
 
   test "h3 can follow an h5" do
     assert_equal "Sub heading 4.2", structured_headers[3].headers[1].text
+  end
+
+  test "headers that are links are based on the link text not the link" do
+    assert_equal "Heading 5.1", structured_headers[4].headers[0].text
+    assert_equal "heading-51", structured_headers[4].headers[0].id
   end
 
   test "structured headers serialize to hashes recursively serializing sub headers" do


### PR DESCRIPTION
- The page https://www.gov.uk/guidance/employment-tribunal-offices-and-venues (before and after links at the bottom), has h2 elements in govspeak that are links. Government Frontend, picking the text out of HTML on the fly to create the contents list, handled this somehow. When we moved it to publish time (picking the links out of govspeak), we introduced a bug where the markdown would be used as the link title in the content list.
- This pattern (of H2s as links) is itself not a good idea and may cause accessibility issues.  We should try to dissuade people from using it. That said, we should at least handle it gracefully. This commit allows us to filter out the markdown link and extract only the link text as our header item.

- before headers collected in Whitehall: https://webarchive.nationalarchives.gov.uk/ukgwa/20250716183242/https://www.gov.uk/guidance/employment-tribunal-offices-and-venues
- after headers collected in Whitehall: https://webarchive.nationalarchives.gov.uk/ukgwa/20250813183618/https://www.gov.uk/guidance/employment-tribunal-offices-and-venues

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.


