### PR TITLE
[PP-7718] Pin SHAs for third-party actions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -6,7 +6,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           show-progress: false
       - uses: alphagov/govuk-infrastructure/.github/actions/actionlint@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
         ruby: [3.3, 3.4, 4.0]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.ref || github.ref }}
-    - uses: ruby/setup-ruby@v1.308.0
+    - uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1.308.0
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true

--- a/.github/workflows/copy-pr-template-to-dependabot-prs.yml
+++ b/.github/workflows/copy-pr-template-to-dependabot-prs.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Post PR template as a comment
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs')


### PR DESCRIPTION
Pins non-alphagov actions to a commit SHA.

As per [policy](https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-with-github-actions.html#pin-untrusted-github-actions-to-a-commit-sha).