### PR TITLE
Add cards to govspeak

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,6 +697,67 @@ which outputs
 </a>
 ```
 
+### Cards
+
+Adds cards using the cards component from the components gem, using the [auto layout](https://components.publishing.service.gov.uk/component-guide/cards/auto_layout).
+
+#### Examples
+
+The most basic card.
+
+```
+{cards}[Benefits](https://www.gov.uk/browse/benefits){/cards}
+```
+
+which outputs
+
+```html
+<div class="gem-c-cards gem-c-cards--auto-layout">
+  <ul class="gem-c-cards__list">
+    <li class="gem-c-cards__list-item">
+      <div class="gem-c-cards__list-item-wrapper">
+        <h3 class="gem-c-cards__sub-heading govuk-heading-s">
+          <a class="govuk-link gem-c-cards__link gem-print-force-link-styles" href="http://www.gov.uk/browse/benefits">Benefits</a>
+        </h3>
+      </div>
+    </li>
+  </ul>
+</div>
+```
+
+To include a description on the card, include after the link.
+
+```
+{cards}[Benefits](https://www.gov.uk/browse/benefits) Includes eligibility, appeals, tax credits and Universal Credit{/cards}
+```
+
+which outputs
+
+```html
+<div class="gem-c-cards gem-c-cards--auto-layout">
+  <ul class="gem-c-cards__list">
+    <li class="gem-c-cards__list-item">
+      <div class="gem-c-cards__list-item-wrapper">
+        <h3 class="gem-c-cards__sub-heading govuk-heading-s">
+          <a class="govuk-link gem-c-cards__link gem-print-force-link-styles" href="http://www.gov.uk/browse/benefits">Benefits</a>
+        </h3>
+        <p class="govuk-body gem-c-cards__description">Includes eligibility, appeals, tax credits and Universal Credit</p>
+      </div>
+    </li>
+  </ul>
+</div>
+```
+
+To output more than one card, repeat the link pattern.
+
+```
+{cards}
+  [Benefits](https://www.gov.uk/browse/benefits) Includes eligibility, appeals, tax credits and Universal Credit
+  [Births, deaths, marriages and care](https://www.gov.uk/browse/births-deaths-marriages) Parenting, civil partnerships, divorce and Lasting Power of Attorney
+{/cards}
+```
+
+
 ## Licence
 
 [MIT License](LICENCE)

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -204,19 +204,18 @@ module Govspeak
 
     extension("cards", %r$^{cards}(.*?){/cards}$m) do |body|
       links = body.scan(/\s*\[([^\]]+)\]\(([^)]+)\)([^{\[$*\#]*)\s*/)
-      all_links = []
+      cards = ""
 
       links.each do |text, href, description|
-        all_links << {
-          link: {
-            text: text,
-            path: href,
-          },
-          description: description,
-        }
+        cards << "
+          <a class='card' href='#{href.strip}'>
+            <span class='text'>#{text.strip}</span>
+            <span class='description'>#{description.strip}</span>
+          </a>
+        "
       end
 
-      GovukPublishingComponents.render("govuk_publishing_components/components/cards", { items: all_links, columns: "auto", margin_bottom: 6 }).to_s
+      "<div class='cards'>#{cards}</div>"
     end
 
     extension("highlight-answer") do |body|

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -202,6 +202,23 @@ module Govspeak
       %(\n<a role="button" draggable="false" class="#{button_classes}" href="#{href}" #{data_attribute}>#{text}</a>\n)
     end
 
+    extension("cards", %r$^{cards}(.*?){/cards}$m) do |body|
+      links = body.scan(/\s*\[([^\]]+)\]\(([^)]+)\)([^{\[$*\#]*)\s*/)
+      all_links = []
+
+      links.each do |text, href, description|
+        all_links << {
+          link: {
+            text: text,
+            path: href,
+          },
+          description: description,
+        }
+      end
+
+      GovukPublishingComponents.render("govuk_publishing_components/components/cards", { items: all_links, columns: "auto", margin_bottom: 6 }).to_s
+    end
+
     extension("highlight-answer") do |body|
       %(\n\n<div class="highlight-answer">
 #{Govspeak::Document.new(body.strip, locale: @locale).to_html}</div>\n)

--- a/lib/govspeak/html_validator.rb
+++ b/lib/govspeak/html_validator.rb
@@ -14,6 +14,7 @@ class Govspeak::HtmlValidator
   def valid?
     dirty_html = govspeak_to_html(sanitize: false)
     clean_html = govspeak_to_html(sanitize: true)
+
     normalise_html(dirty_html) == normalise_html(clean_html)
   end
 

--- a/lib/govspeak/post_processor.rb
+++ b/lib/govspeak/post_processor.rb
@@ -147,6 +147,30 @@ module Govspeak
       end
     end
 
+    extension("use gem component for cards") do |document|
+      document.css(".cards").map do |cards|
+        links = cards.css(".card").map do |card|
+          {
+            link: {
+              path: card["href"],
+              text: card.css(".text").inner_html.html_safe,
+            },
+            description: card.css(".description").inner_html.html_safe,
+          }
+        end
+
+        cards_html = GovukPublishingComponents.render(
+          "govuk_publishing_components/components/cards", {
+            items: links,
+            columns: "auto",
+            margin_bottom: 6,
+          }
+        ).squish.gsub("> <", "><").gsub!(/\s+/, " ")
+
+        cards.swap(cards_html)
+      end
+    end
+
     extension("use custom footnotes") do |document|
       document.css("a.footnote").map do |el|
         footnote_number = el[:href].gsub(/\D/, "")

--- a/test/govspeak_cards_test.rb
+++ b/test/govspeak_cards_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+require "govspeak_test_helper"
+
+require "ostruct"
+
+class GovspeakTest < Minitest::Test
+  include GovspeakTestHelper
+
+  test_given_govspeak "{cards}[Benefits](https://www.gov.uk/browse/benefits){/cards}" do
+    assert_html_selector ".gem-c-cards.gem-c-cards--auto-layout"
+    assert_html_selector 'a.gem-c-cards__link[href="https://www.gov.uk/browse/benefits"]'
+    assert_text_output "Benefits"
+  end
+
+  # The same as above but with line breaks
+  test_given_govspeak "{cards}\n\n\n[Benefits](https://www.gov.uk/browse/benefits)\n\n\n{/cards}" do
+    assert_html_selector 'a.gem-c-cards__link[href="https://www.gov.uk/browse/benefits"]'
+    assert_text_output "Benefits"
+  end
+
+  test_given_govspeak "{cards}\n[Benefits](https://www.gov.uk/browse/benefits)\n[Births, deaths, marriages and care](https://www.gov.uk/browse/births-deaths-marriages)\n{/cards}" do
+    assert_html_selector 'a.gem-c-cards__link[href="https://www.gov.uk/browse/benefits"]'
+    assert_html_selector 'a.gem-c-cards__link[href="https://www.gov.uk/browse/births-deaths-marriages"]'
+    assert_text_output "Benefits Births, deaths, marriages and care"
+  end
+
+  test_given_govspeak "{cards}[Benefits](https://www.gov.uk/browse/benefits) This is a description{/cards}" do
+    assert_html_selector 'a.gem-c-cards__link[href="https://www.gov.uk/browse/benefits"]'
+    assert_html_selector ".gem-c-cards__description"
+    assert_text_output "Benefits This is a description"
+  end
+
+  # The same as above but with line breaks
+  test_given_govspeak "{cards}\n\n[Benefits](https://www.gov.uk/browse/benefits)\n\nThis is a description\n\n{/cards}" do
+    assert_html_selector 'a.gem-c-cards__link[href="https://www.gov.uk/browse/benefits"]'
+    assert_text_output "Benefits This is a description"
+  end
+
+  test_given_govspeak "{cards}\n\n[Benefits](https://www.gov.uk/browse/benefits)\n\nThis is a description? With punctuation! - of course, this isn't a real example, real ones wouldn't \"quote\" like this\n\n{/cards}" do
+    assert_html_selector 'a.gem-c-cards__link[href="https://www.gov.uk/browse/benefits"]'
+    assert_text_output "Benefits This is a description? With punctuation! - of course, this isn't a real example, real ones wouldn't \"quote\" like this"
+  end
+
+  test_given_govspeak "{cards}\n
+    [Benefits](https://www.gov.uk/browse/benefits)\n
+    This is a description\n
+    containing line breaks\n
+    [Births, deaths, marriages and care](https://www.gov.uk/browse/births-deaths-marriages)\n
+    {/cards}" do
+    assert_html_selector 'a.gem-c-cards__link[href="https://www.gov.uk/browse/benefits"]'
+    assert_html_selector 'a.gem-c-cards__link[href="https://www.gov.uk/browse/births-deaths-marriages"]'
+    assert_text_output "Benefits This is a description containing line breaks Births, deaths, marriages and care"
+  end
+end


### PR DESCRIPTION
## What
Adds the [cards component](https://components.publishing.service.gov.uk/component-guide/cards) to govspeak.

Specifically, uses the cards component in `auto` mode, which makes the cards [display flexibly based on their container](https://components.publishing.service.gov.uk/component-guide/cards/auto_layout), with a `margin_bottom` of `6`.

Cards can be created in govspeak as follows:

```
{cards}
  [Benefits](https://www.gov.uk/browse/benefits) Includes eligibility, appeals, tax credits and Universal Credit
  [Births, deaths, marriages and care](https://www.gov.uk/browse/births-deaths-marriages) Parenting, civil partnerships, divorce and Lasting Power of Attorney
{/cards}
```

See included documentation for more examples.

## Why
Needed to reproduce the missions pages in a better format.

## Visual changes
Cards look like this:

<img width="676" height="416" alt="Screenshot 2026-06-18 at 14 13 27" src="https://github.com/user-attachments/assets/42e85963-659d-43b7-abf4-b270aa12c0ec" />
